### PR TITLE
Typos in the API-Keys documentation

### DIFF
--- a/apikeys-de.md
+++ b/apikeys-de.md
@@ -123,9 +123,9 @@ Deutsch &bull; [English](apikeys-en.md)
 | deltap     | R          | float                        | Status        | deltaP                                                                              |
 | pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
 | deltaa     | R          | float                        | Other         | deltaA                                                                              |
-| pvopt_avergagePGrid | R | float                        | Status        | averagePGrid                                                                        |
-| pvopt_avergagePPV | R   | float                        | Status        | averagePPv                                                                          |
-| pvopt_avergagePAkku | R | float                        | Status        | averagePAkku                                                                        |
+| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
+| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
+| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
 | mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
 | mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
 | mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |

--- a/apikeys-en.md
+++ b/apikeys-en.md
@@ -123,9 +123,9 @@
 | deltap     | R          | float                        | Status        | deltaP                                                                              |
 | pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
 | deltaa     | R          | float                        | Other         | deltaA                                                                              | 
-| pvopt_avergagePGrid | R | float                        | Status        | averagePGrid                                                                        |
-| pvopt_avergagePPV | R   | float                        | Status        | averagePPv                                                                          |
-| pvopt_avergagePAkku | R | float                        | Status        | averagePAkku                                                                        |
+| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
+| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
+| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
 | mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
 | mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
 | mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |


### PR DESCRIPTION
Hi - I just came across this three typos in the documentation

1. typo 'avergage*' -> 'average*'
2. false case 'PPV' -> 'PPv'