### PR TITLE
Document ids command

### DIFF
--- a/apikeys-de.md
+++ b/apikeys-de.md
@@ -89,6 +89,7 @@ Deutsch &bull; [English](apikeys-en.md)
 | awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
 | awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
 | ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
+| ids        | R/W        | bool                         | Other         | PvSurPlus Information. z.b.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.}  pGrid < 0 ==> Einspeisen, pAkku < 0 ==> Batterie laden, pPv > 0 ==> PV Produktion, pPv < 0 ==> Standby. Muß alle 5 Sekunden geschrieben werden. Kann bis 10 Sekunden nach Schreiben gelesen werden. pPv und pAkku sind optional |
 | frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
 | fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
 | awe        | R/W        | bool                         | Config        | useAwattar                                                                          |

--- a/apikeys-en.md
+++ b/apikeys-en.md
@@ -89,6 +89,7 @@
 | awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
 | awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
 | ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
+| ids        | R/W        | bool                         | Other         | PvSurPlus information. e.g.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.} pGrid < 0 ==> feed grid, pAkku < 0 ==> load battery, pPv > 0 ==> PV production, pPv < 0 ==> standby. Needed all 5 seconds. Can be read back within 10 seconds after set. pPv und pAkku are optional |
 | frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
 | fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
 | awe        | R/W        | bool                         | Config        | useAwattar                                                                          |


### PR DESCRIPTION
Contains a summary of info provided by @0xFEEDC0DE64 in https://github.com/goecharger/go-eCharger-API-v2/discussions/110

Usage
e.g. http://x.x.x.x/api/set?ids={"pPv":1500,"pGrid":1500,"pAkku":1200}

See also for a full blown example
https://gist.github.com/schinagl/849d04f127f4ad53b5b1030a6feacdb0