### PR TITLE
First try to export the api keys directly from the firmware

### DIFF
--- a/apikeys-en.md
+++ b/apikeys-en.md
@@ -4,273 +4,278 @@
 
 | Key        | R/W        | Type                         | Category      | Description                                                                         |
 | ---------- | ---------- | ---------------------------- | ------------- | ----------------------------------------------------------------------------------- |
-| acp        | R/W        | bool                         | Config        | allowChargePause (car compatiblity)                                                 |
-| acs        | R/W        | uint8                        | Config        | access_control user setting (Open=0, Wait=1)                                        |
-| acu        | R          | int                          | Status        | How many ampere is the car allowed to charge now?                                   |
-| adi        | R          | bool                         | Status        | Is the 16A adapter used? Limits the current to 16A                                  |
+| rst        | W          | JsonVariantConst             | Unknown       | Reset the charger and chargectrl                                                    |
 | alw        | R          | bool                         | Status        | Is the car allowed to charge at all now?                                            |
-| ama        | R/W        | uint8                        | Config        | ampere_max limit                                                                    |
-| amp        | R/W        | uint8                        | Config        | requestedCurrent in Ampere, used for display on LED ring and logic calculations     |
-| amt        | R          | int                          | Status        | temperatureCurrentLimit                                                             |
-| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
-| ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
-| atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
-| att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
-| avgfhz | R | TYPE | Status | Stromnetz average frequency (~50Hz) + |
-| awc        | R/W        | uint8                        | Config        | awattar country (Austria=0, Germany=1)                                              |
-| awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
-| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
-| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
-| awpl | W | TYPE | Status | awattar price list, timestamps are measured in unix-time, seconds since 1970 + |
-| bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| bar | R/W | TYPE | Config | Button Allow WiFi AP reset (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) + |
-| car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
-| cards      | R/W        | array                        | Config        | array of user data (name, energy used, activation state)                            |
-| cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
-| ccd | R | TYPE | Status | Connected controller data + | cch | R/W | TYPE | Config | color_charging, format: #RRGGBB + |
-| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
-| cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
-| ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
-| ccu        | R          | optional&lt;object&gt;       | Status        | charge controller update progress (null if no update is in progress)                |
-| ccw        | R          | optional&lt;object&gt;       | Status        | Currently connected WiFi                                                            |
-| cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
-| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
-| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
-| cle | R | TYPE | Status | Cloud last error + |
-| clea | R | TYPE | Status | Cloud last error (age) + |
-| cll | R | TYPE | Status | Current limits list + |
-| clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
-| cmmr | R | TYPE | Config | controllerMdnsMaxResults + |
-| cmp | R | TYPE | Config | controllerMdnsProto + |
-| cms | R | TYPE | Config | controllerMdnsService + |
-| cmse | R | TYPE | Config | controllerMdnsScanEnabled, set to false to completely disable any MDNS searches (debugging) + |
-| csa | R | TYPE | Status | controller scan active + |
-| ct | R/W | TYPE | Config | car type, free text string (max. 64 characters) + |
-| ctrls | R | TYPE | Status | Controllers search result + |
-| cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
-| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
-| cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
-| data | R | TYPE | Status | grafana token from cloud for app + |
-| del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
-| deltaa     | R          | float                        | Other         | deltaA                                                                              | 
-| deltap     | R          | float                        | Status        | deltaP                                                                              |
-| delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
-| di1 | R/W | TYPE | Config | digital Input 1-phase + |
-| die | R/W | TYPE | Config | digital Input Enabled + |
-| dii | R/W | TYPE | Config | digital Input Inverted + |
-| dll | R | TYPE | Status | download link for app csv export + |
-| dns        | R          | object                       | Status        | DNS server                                                                          |
-| dsrc | R | TYPE | Status | inverter data source + |
-| dwo        | R/W        | optional&lt;double&gt;       | Config        | charging energy limit, measured in Wh, null means disabled, not the next-trip energy |
-| err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
-| esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
-| eto        | R          | uint64                       | Status        | energy_total, measured in Wh                                                        |
-| ferm       | R          | uint8                        | Status        | effectiveRoundingMode                                                               |
-| ffb        | R          | uint8                        | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
-| fhz        | R          | optional&lt;float&gt;        | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
-| fmt        | R/W        | milliseconds                 | Config        | minChargeTime in milliseconds                                                       |
-| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
-| frc        | R/W        | uint8                        | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
-| frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
-| fsp        | R          | bool                         | Status        | force_single_phase, das Rechenergebnis der Ladelogik, ob gerade single phase benötigt wird oder nicht. |
-| fsptws     | R          | optional&lt;milliseconds&gt; | Status        | force single phase toggle wished since                                              |
-| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
-| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
-| fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
-| fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
-| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
-| gmtr | R/W | TYPE | Config | gridMonitoringTimeReconnection in seconds + |
-| gsa | R/W | TYPE | Status | gridMonitoring last failure + |
-| hai | R/W | TYPE | Config | httpApiEnabled (allows /api/status and /api/set requests) + |
-| hla | R/W | TYPE | Config | httpLegacyApiEnabled (allows /status and /mqtt requests) + |
-| host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
-| hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
-| ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
-| ids        | R/W        | bool                         | Other         | PvSurPlus information. e.g.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.} pGrid < 0 ==> feed grid, pAkku < 0 ==> load battery, pPv > 0 ==> PV production, pPv < 0 ==> standby. Needed all 5 seconds. Can be read back within 10 seconds after set. pPv und pAkku are optional |
-| inva       | R          | milliseconds                 | Status        | age of inverter data                                                                |
-| la1 | R/W | TYPE | Config | limit adapter 1-phase (in A) + |
-| la3 | R/W | TYPE | Config | limit adapter 3-phase (in A) + |
-| lbl | R | TYPE | Config | lastButtonHoldLong + |
-| lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
-| lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
-| lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
-| lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
-| lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
-| lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
-| lcs | R | TYPE | Status | last controller scan timestamp in milliseconds since boot time + |
-| led        | R          | object                       | Status        | internal infos about currently running led animation                                |
-| lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
-| lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
-| lmsc       | R          | milliseconds                 | Status        | last model status change                                                            |
-| loa        | R          | optional&lt;uint8&gt;        | Status        | load balancing ampere                                                               |
-| loc        | R          | string                       | Status        | local time                                                                          |
-| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
-| lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
-| log        | R/W        | string                       | Config        | load_group_id                                                                       |
-| lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
-| lopr | R/W | TYPE | Config | load balancing protected + |
-| lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
-| loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
-| lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
-| lrc | R | TYPE | Status | last rfid card index + |
-| lri | R | TYPE | Status | last rfid id (only available when sendRfid) + |
-| lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
-| lrr | R | TYPE | Status | last rfid read (milliseconds since boot) + |
-| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
-| lto | R | TYPE | Status | local time offset in milliseconds, tab + rbt + lto = local time + |
-| lwf | R | TYPE | Status | last wifi connect failed (milliseconds since boot) + |
-| map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
-| mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
-| mcc | R | TYPE | Status | MQTT connected + |
-| mcca | R | TYPE | Status | MQTT connected (age) + |
-| mce | R/W | TYPE | Config | MQTT enabled + |
-| mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
-| mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
-| mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |
-| mcr | R/W | TYPE | Config | MQTT readonly (don't allow api writes from mqtt broker) + |
-| mcs | R | TYPE | Status | MQTT started + |
-| mcu | R/W | TYPE | Config | MQTT broker url + |
-| men | R/W | TYPE | Config | modbus slave enabled + |
-| mhe | R/W | TYPE | Config | MQTT enable homeassistant discovery + |
-| mht | R/W | TYPE | Config | MQTT homeassistant topic prefix (set to null to reset back to the default) + |
-| mlr | R | TYPE | Status | MQTT last error + |
-| mlra | R | TYPE | Status | MQTT last error (age) + |
-| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
-| modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
-| mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
-| mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
-| mqcn | R/W | TYPE | Config | MQTT skipCertCommonNameCheck + |
-| mqg | R/W | TYPE | Config | MQTT useGlobalCaStore + |
-| mqss | R/W | TYPE | Config | MQTT skipServerVerification + |
-| msb | R/W | TYPE | Config | modbus slave swap bytes + |
-| msp | R/W | TYPE | Config | modbus slave port (requires off/on toggle) + |
-| msr | R/W | TYPE | Config | modbus slave swap registers + |
-| mtp | R/W | TYPE | Config | MQTT topic prefix (set to null to reset back to the default) + |
-| nif        | R          | string                       | Status        | Default route                                                                       |
-| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
-| nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
-| ocppa   | R    | bool      | Status   | OCPP connected and accepted |
-| ocppaa  | R | null or milliseconds | Status | OCPP connected and accepted (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
-| ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppao | R/W | TYPE | Status | OCPP AllowOfflineTxForUnknownId + |
-| ocppc   | R    | bool     | Status   | OCPP connected               |
-| ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
-| ocppcc  | R/W  | string   | Config   | OCPP client cert             |
-| ocppck  | R/W  | string   | Config   | OCPP client key              |
-| ocppcm | R/W | TYPE | Status | OCPP LocalAuthListEnabled + |
-| ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
-| ocppcs | R | TYPE | Status | OCPP connector status (0=Available, 1=Preparing, 2=Charging, 3=SuspendedEVSE, 4=SuspendedEV, 5=Finishing, 6=Reserved, 7=Unavailable, 8=Faulted) + |
-| ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
-| ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
-| ocppf | R/W | TYPE | Config | OCPP fallback current + |
-| ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
-| ocpph   | R/W | seconds | Config | OCPP heartbeat interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppi   | R/W | seconds | Config | OCPP meter values sample interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppla | R/W | TYPE | Status | OCPP LocalAuthListEnabled + |
-| ocpple  | R | string or null | Status | OCPP last error               |
-| ocpplea | R | null or milliseconds | Status | OCPP last error (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
-| ocpplo | R/W | TYPE | Status | OCPP LocalAuthorizeOffline + |
-| ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
-| ocpprl  | R/W | bool | Config | OCPP remote logging (usually only enabled by go-e support to allow debugging) |
-| ocpps   | R    | bool     | Status   | OCPP started                 |
-| ocppsc  | R/W  | string   | Config   | OCPP server cert             |
-| ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
-| ocppti | R/W | TYPE | Status | OCPP transaction id + |
-| ocppu   | R/W  | string   | Config   | OCPP server url              |
-| oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
-| ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
-| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
-| pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
-| pco | R | TYPE | Config | controllerCloudKey + |
-| pdi | R/W | TYPE | Config | protect Digital Input + |
-| pgr | R/W | TYPE | Config | protect Grid Requirements + |
-| pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
-| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
-| pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
-| pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
-| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
-| ppv        | R          | optional&lt;float&gt;        | Status        | pPv in W                                                                            |
-| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
-| psm        | R/W        | uint8                        | Config        | phaseSwitchMode (Auto=0, Force_1=1, Force_3=2)                                      |
-| psmd       | R/W        | milliseconds                 | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
-| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
-| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
-| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
-| pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
-| rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
-| rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
-| rdbf | R/W | TYPE | Config | randomDelayStartFlexibleTariffCharging in seconds + |
-| rdbfe | R/W | TYPE | Config | randomDelayStartFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStartFlexibleTariffCharging) + |
-| rdbs | R/W | TYPE | Config | randomDelayStartScheduledCharging in seconds + |
-| rdbse | R/W | TYPE | Config | randomDelayStartScheduledChargingEndsAt (set to null to abort current randomDelayStartScheduledCharging) + |
-| rde | R/W | TYPE | Config | send rfid serial to cloud/api/mqtt (enable lri api key to show rfid numbers) + |
-| rdef | R/W | TYPE | Config | randomDelayStopFlexibleTariffCharging in seconds + |
-| rdefe | R/W | TYPE | Config | randomDelayStopFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStopFlexibleTariffCharging) + |
-| rdes | R/W | TYPE | Config | randomDelayStopScheduledCharging in seconds + |
-| rdese | R/W | TYPE | Config | randomDelayStopScheduledChargingEndsAt (set to null to abort current randomDelayStopScheduledCharging) + |
-| rdpl | R/W | TYPE | Config | randomDelayWhenPluggingCar in seconds + |
-| rdple | R/W | TYPE | Config | randomDelayWhenPluggingCarEndsAt (set to null to abort current randomDelayWhenPluggingCar) + |
-| rdre | R/W | TYPE | Config | randomDelayReconnection in seconds + |
-| rdree | R/W | TYPE | Config | randomDelayReconnectionEndsAt (set to null to abort current randomDelayReconnection) + |
-| rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
-| rmaf | R/W | TYPE | Config | reconnectionMaximumFrequency in Hz + |
-| rmav | R/W | TYPE | Config | reconnectionMaximumVoltage in Volt + |
-| rmif | R/W | TYPE | Config | reconnectionMinimumFrequency in Hz + |
-| rmiv | R/W | TYPE | Config | reconnectionMinimumVoltage in Volt + |
-| rsa | R/W | TYPE | Status | rampup started at + |
-| rsre | R/W | TYPE | Config | rampupAtStartAndReconnectionEnabled + |
-| rsrr | R/W | TYPE | Config | rampupAtStartAndReconnectionRate in %/s + |
-| rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
-| rst        | W          | any                          | Other         | Reboot charger                                                                      |
-| scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
-| scan       | R          | array                        | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
-| sch_satur  | R/W        | object                       | Config        | scheduler_saturday, control enum values: Disabled=0, Inside=1, Outside=2            |
-| sch_sund   | R/W        | object                       | Config        | scheduler_sunday, control enum values: Disabled=0, Inside=1, Outside=2              |
-| sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
-| sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
-| smd | R | TYPE | Status | smart meter data + |
-| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
+| acu        | R          | optional<int>                | Status        | How many ampere is the car allowed to charge now?                                   |
+| cll        | R          | legacy                       | Status        | Current limits list                                                                 |
+| adi        | R          | bool                         | Status        | Is the 16A adapter used? Limits the current to 16A                                  |
+| dwo        | R/W        | optional<double>             | Config        | energy limit, measured in Wh, null means disabled, not the next trip energy         |
+| tpa        | R          | float                        | Status        | 30 seconds total power average (not used by next-trip, use mmp for next-trip related power) |
 | sse        | R          | string                       | Constant      | serial number                                                                       |
+| eto        | R          | uint64_t                     | Status        | energy_total, measured in Wh                                                        |
+| wifis      | R/W        | get: legacy set: JsonArray   | Config        | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: [{}, {"ssid":"","key":""}] |
+| delw       | W          | uint8_t                      | Unknown       | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
+| scan       | R          | legacy                       | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
+| lwf        | R          | optional<int64_t>            | Status        | last wifi connect failed (milliseconds since boot)                                  |
+| scaa       | R          | optional<int64_t>            | Status        | wifi scan age                                                                       |
+| wst        | R          | uint8_t                      | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=7, DISCONNECTING=8, NO_SHIELD=9, WAITING_FOR_IP=10 (for compatibility with WiFi Shield library)) |
+| wsc        | R          | uint8_t                      | Status        | WiFi STA error count                                                                |
+| wsl        | R          | legacy                       | Status        | WiFi STA error messages log                                                         |
+| wsms       | R          | uint8_t                      | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
+| ccw        | R          | legacy                       | Status        | Currently connected WiFi                                                            |
+| wfb        | R          | legacy                       | Status        | WiFi failed mac addresses (bssids)                                                  |
+| wcb        | R          | string                       | Status        | WiFi current mac address (bssid connecting to)                                      |
+| wpb        | R          | legacy                       | Status        | WiFi planned mac addresses (future bssids)                                          |
+| nif        | R          | string                       | Status        | Default route                                                                       |
+| dns        | R          | legacy                       | Status        | dns servers                                                                         |
+| host       | R          | string                       | Status        | configured hostname                                                                 |
+| wbw        | R          | unsigned int                 | Config        | WiFi Bandwidth (for both AP and STA) WIFI_BW_HT20=1, WIFI_BW_HT40=2                 |
+| rssi       | R          | optional<int8_t>             | Status        | RSSI signal strength                                                                |
+| wda        | R/W        | bool                         | Config        | disable AccessPoint when cloud is connected                                         |
+| mia        | R          | legacy                       | Status        | Modem IP Address                                                                    |
+| tse        | R/W        | bool                         | Config        | time server enabled                                                                 |
+| tsss       | R          | unsigned int                 | Status        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
+| tof        | R/W        | int32_t                      | Config        | timezone offset in minutes                                                          |
+| tds        | R/W        | uint8_t                      | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2, AustralianDaylightTime=3 |
+| tzt        | R/W        | string                       | Config        | timezone type, freetext string for app selection                                    |
+| utc        | R/W        | string                       | Status        | utc time                                                                            |
+| loc        | R          | string                       | Status        | local time                                                                          |
+| tab        | R          | uint64_t                     | Status        | time at boot in utc in milliseconds, add rbt to get to current utc time             |
+| lto        | R          | int64_t                      | Status        | local time offset in milliseconds, tab + rbt + lto = local time                     |
+| led        | R          | legacy                       | Status        | LED animation                                                                       |
+| lbr        | R/W        | uint8_t                      | Config        | led_bright, 0-255                                                                   |
+| lmo        | R/W        | uint8_t                      | Config        | logic mode (Default=3, Awattar=4, NextTrip=5)                                       |
+| ama        | R/W        | uint8_t                      | Config        | ampere_max limit                                                                    |
+| tcl        | R/W        | optional<uint8_t>            | Config        | temporary current limit (does not change the user current limit, will be reset after 10min if not updated regulary) |
+| die        | R/W        | bool                         | Config        | digital Input Enabled                                                               |
+| dii        | R/W        | bool                         | Config        | digital Input Inverted                                                              |
+| din        | R          | uint32_t                     | Status        | digital input states                                                                |
+| la1        | R/W        | uint8_t                      | Config        | limit adapter 1-phase (in A)                                                        |
+| la3        | R/W        | uint8_t                      | Config        | limit adapter 3-phase (in A)                                                        |
+| di1        | R/W        | bool                         | Config        | digital Input 1-phase                                                               |
+| pgr        | R/W        | bool                         | Config        | protect Grid Requirements                                                           |
+| pdi        | R/W        | bool                         | Config        | protect Digital Input                                                               |
+| ufe        | R/W        | bool                         | Config        | Underfrequency Control enabled                                                      |
+| ufm        | R/W        | uint8_t                      | Config        | Underfrequency Control mode (TypeNominal=0, TypeActual=1)                           |
+| ufa        | R/W        | float                        | Config        | Underfrequency Control activation threshold                                         |
+| ufs        | R/W        | float                        | Config        | Underfrequency Control stop frequency                                               |
+| clp        | R/W        | get: legacy set: JsonArray   | Config        | current limit presets, max. 5 entries                                               |
+| bac        | R/W        | get: uint8_t set: JsonVariantConst | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| sdp        | R/W        | get: uint8_t set: JsonVariantConst | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| bar        | R/W        | uint8_t                      | Config        | Button Allow WiFi AP reset (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| lbp        | R          | optional<int64_t>            | Config        | lastButtonPress                                                                     |
+| lbl        | R          | optional<int64_t>            | Config        | lastButtonHoldLong                                                                  |
+| amp        | R/W        | uint8_t                      | Config        | requestedCurrent, used for display on LED ring and logic calculations               |
+| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
+| isgo       | R          | bool                         | Constant      | is go                                                                               |
+| simo       | R          | bool                         | Config        | simplified mode                                                                     |
+| aus        | R          | bool                         | Config        | is australia                                                                        |
+| rdbs       | R/W        | int32_t                      | Config        | randomDelayStartScheduledCharging in seconds                                        |
+| rdes       | R/W        | int32_t                      | Config        | randomDelayStopScheduledCharging in seconds                                         |
+| rdbf       | R/W        | int32_t                      | Config        | randomDelayStartFlexibleTariffCharging in seconds                                   |
+| rdef       | R/W        | int32_t                      | Config        | randomDelayStopFlexibleTariffCharging in seconds                                    |
+| rdre       | R/W        | int32_t                      | Config        | randomDelayReconnection in seconds                                                  |
+| rdpl       | R/W        | int32_t                      | Config        | randomDelayWhenPluggingCar in seconds                                               |
+| rdbse      | R/W        | optional<int64_t>            | Config        | randomDelayStartScheduledChargingEndsAt (set to null to abort current randomDelayStartScheduledCharging) |
+| rdese      | R/W        | optional<int64_t>            | Config        | randomDelayStopScheduledChargingEndsAt (set to null to abort current randomDelayStopScheduledCharging) |
+| rdbfe      | R/W        | optional<int64_t>            | Config        | randomDelayStartFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStartFlexibleTariffCharging) |
+| rdefe      | R/W        | optional<int64_t>            | Config        | randomDelayStopFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStopFlexibleTariffCharging) |
+| rdree      | R/W        | optional<int64_t>            | Config        | randomDelayReconnectionEndsAt (set to null to abort current randomDelayReconnection) |
+| rdple      | R/W        | optional<int64_t>            | Config        | randomDelayWhenPluggingCarEndsAt (set to null to abort current randomDelayWhenPluggingCar) |
+| gmtr       | R/W        | int32_t                      | Config        | gridMonitoringTimeReconnection in seconds                                           |
+| gsa        | R/W        | optional<int64_t>            | Status        | gridMonitoring last failure                                                         |
+| rsa        | R/W        | optional<int64_t>            | Status        | rampup started at                                                                   |
+| rmiv       | R/W        | float                        | Config        | reconnectionMinimumVoltage in Volt                                                  |
+| rmav       | R/W        | float                        | Config        | reconnectionMaximumVoltage in Volt                                                  |
+| rmif       | R/W        | float                        | Config        | reconnectionMinimumFrequency in Hz                                                  |
+| rmaf       | R/W        | float                        | Config        | reconnectionMaximumFrequency in Hz                                                  |
+| rsre       | R/W        | bool                         | Config        | rampupAtStartAndReconnectionEnabled                                                 |
+| rsrr       | R/W        | float                        | Config        | rampupAtStartAndReconnectionRate in %/s                                             |
+| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
+| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
+| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
+| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
+| ust        | R/W        | uint8_t                      | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
+| lck        | R          | uint8_t                      | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
+| sch_week   | R/W        | get: legacy set: JsonObject  | Config        | scheduler_weekday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| sch_satur  | R/W        | get: legacy set: JsonObject  | Config        | scheduler_saturday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| sch_sund   | R/W        | get: legacy set: JsonObject  | Config        | scheduler_sunday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled                     |
+| fsp        | R/W        | bool                         | Status        | force_single_phase                                                                  |
+| lrn        | W          | uint8_t                      | Config        | set this to 0-9 to learn last read card id                                          |
+| del        | W          | uint8_t                      | Unknown       | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
+| acs        | R/W        | uint8_t                      | Config        | access_control user setting (Open=0, Wait=1, EVCMS=2)                               |
+| frc        | R/W        | uint8_t                      | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
+| rbc        | R          | uint32_t                     | Status        | reboot_counter                                                                      |
+| rbt        | R          | int64_t                      | Status        | time since boot in milliseconds                                                     |
+| car        | R          | optional<uint8_t>            | Status        | charge ctrl car state, null if no connection to chargectrl established (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
+| err        | R          | optional<uint8_t>            | Status        | charge ctrl error, null if no connection to charge ctrl established (None=0, FiAc=1, FiDc=2, Phase=3, Overvolt=4, Overamp=5, Diode=6, PpInvalid=7, GndInvalid=8, ContactorStuck=9, ContactorMiss=10, StatusLockStuckOpen=12, StatusLockStuckLocked=13, FiUnknown=14, Unknown=15, Overtemp=16, NoComm=17, CpInvalid=18) |
+| cbl        | R          | optional<int>                | Status        | cable_current_limit in A                                                            |
+| pha        | R          | legacy                       | Status        | phases                                                                              |
+| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
+| whs        | R          | double                       | Status        | energy SOLAR in Wh since car connected                                              |
+| whb        | R          | double                       | Status        | energy BATTERY in Wh since car connected                                            |
+| whg        | R          | double                       | Status        | energy GRID in Wh since car connected                                               |
+| who        | R          | double                       | Status        | energy OTHER in Wh since car connected                                              |
+| ws         | R          | optional<double>             | Status        | power SOLAR in W                                                                    |
+| wb         | R          | optional<double>             | Status        | power BATTERY in W                                                                  |
+| wg         | R          | optional<double>             | Status        | power GRID in W                                                                     |
+| wo         | R          | optional<double>             | Status        | power OTHER in W                                                                    |
+| trx        | R/W        | optional<uint8_t>            | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
+| evt        | R          | optional<string>             | Status        | EVCMS transaction id                                                                |
+| fwv        | R          | string                       | Status        | FW_VERSION                                                                          |
+| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
+| typ        | R          | string                       | Constant      | Devicetype                                                                          |
+| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
+| cdi        | R          | legacy                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
+| lccfi      | R          | optional<int64_t>            | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
+| lccfc      | R          | optional<int64_t>            | Status        | lastCarStateChangedFromCharging (in ms)                                             |
+| lcctc      | R          | optional<int64_t>            | Status        | lastCarStateChangedToCharging (in ms)                                               |
+| tma        | R          | legacy                       | Status        | temperature sensors                                                                 |
+| amt        | R          | int                          | Status        | temperatureCurrentLimit                                                             |
+| nrg        | R          | legacy                       | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
+| modelStatus | R          | uint8_t                      | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControl=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackV2Default=13, ChargingBecauseFallbackV2Scheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackV2Awattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35, NotChargingBecauseOcppInoperable=37) |
+| lmsc       | R          | int64_t                      | Status        | last model status change                                                            |
+| mca        | R/W        | uint8_t                      | Config        | minChargingCurrent                                                                  |
+| awc        | R/W        | uint16_t                     | Config        | awattar country (Austria=0, Germany=1,...)                                          |
+| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
+| awcp       | R          | legacy                       | Status        | awattar current price                                                               |
+| awpl       | W          | get: legacy set: JsonArray   | Status        | awattar price list, timestamps are measured in unix-time, seconds since 1970        |
+| frm        | R/W        | uint8_t                      | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
+| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
+| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
+| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
+| fmt        | R/W        | int32_t                      | Config        | minChargeTime in milliseconds                                                       |
+| att        | R/W        | int32_t                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
+| ate        | R/W        | double                       | Config        | nextTripEnergy in Wh                                                                |
+| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
+| acp        | R/W        | bool                         | Config        | allowChargePause                                                                    |
+| cco        | R/W        | double                       | Config        | car consumption (for app)                                                           |
+| esk        | R/W        | bool                         | Config        | energy set kwh (for app)                                                            |
+| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
+| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
+| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
+| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
+| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
+| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |
+| psmd       | R/W        | int32_t                      | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
+| sumd       | R/W        | int32_t                      | Config        | simulate unpluging duration (in milliseconds)                                       |
+| mpwst      | R/W        | int32_t                      | Config        | min phase wish switch time (in milliseconds)                                        |
+| mptwt      | R/W        | int32_t                      | Config        | min phase toggle wait time (in milliseconds)                                        |
+| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower                                                        |
+| tlf        | R          | bool                         | Status        | testLadungFinished                                                                  |
+| tls        | R          | optional<int64_t>            | Status        | testLadungStarted                                                                   |
+| lpc        | R          | optional<int64_t>            | Status        | lastPvCalculation                                                                   |
+| atp        | R          | legacy                       | Status        | nextTripPlanData                                                                    |
+| lpsc       | R          | optional<int64_t>            | Status        | last pv surplus calcuation                                                          |
+| ids        | W          | optional<JsonObject>         | Status        | inverter data setter {"pGrid": 1000., "pPv": 1000., "pAkku": 1000.}                 |
+| inva       | R          | optional<int64_t>            | Status        | age of inverter data                                                                |
+| pgrid      | R          | optional<float>              | Status        | pGrid in W                                                                          |
+| ppv        | R          | optional<float>              | Status        | pPv in W                                                                            |
+| pakku      | R          | optional<float>              | Status        | pAkku in W                                                                          |
+| dsrc       | R          | optional<string>             | Status        | inverter data source                                                                |
+| deltap     | R          | float                        | Status        | deltaP                                                                              |
+| pnp        | R          | uint8_t                      | Status        | numberOfPhases                                                                      |
+| deltaa     | R          | float                        | Unknown       | deltaA                                                                              |
+| pvopt_averagePGrid | R          | float                        | Status        | averagePGrid                                                                        |
+| pvopt_averagePPv | R          | float                        | Status        | averagePPv                                                                          |
+| pvopt_averagePAkku | R          | float                        | Status        | averagePAkku                                                                        |
+| ct         | R/W        | string                       | Config        | car type, free text string (max. 64 characters)                                     |
+| mci        | R/W        | int32_t                      | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
+| mcpd       | R/W        | int32_t                      | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
+| mcpea      | R/W        | optional<int64_t>            | Config        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |
 | su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
 | sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
-| sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
-| t0h | R/W | TYPE | Config | led strip T0H + |
-| t0l | R/W | TYPE | Config | led strip T0L + |
-| t1h | R/W | TYPE | Config | led strip T1H + |
-| t1l | R/W | TYPE | Config | led strip T1L + |
-| tab | R | TYPE | Status | time at boot in utc in milliseconds, add rbt to get to current utc time + |
-| tcl | R/W | TYPE | Config | temporary current limit (does not change the user current limit, will be reset after 10min if not updated regulary) + |
-| tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
-| tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
-| tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
-| tma        | R          | array                        | Status        | temperature sensors                                                                 |
-| tof        | R/W        | minutes                      | Config        | timezone offset in minutes                                                          |
-| tpa        | R          | float                        | Status        | 30 seconds total power average (used to get better next-trip predictions)           |
-| trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
-| tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
-| tsi | R | TYPE | Status | transaction start rfidid (only available when sendRfid) + |
-| tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
-| typ        | R          | string                       | Constant      | Devicetype                                                                          |
-| tzt | R/W | TYPE | Config | timezone type, freetext string for app selection + |
-| ufa | R/W | TYPE | Config | Underfrequency Control activation threshold + |
-| ufe | R/W | TYPE | Config | Underfrequency Control enabled + |
-| ufm | R/W | TYPE | Config | Underfrequency Control mode (TypeNominal=0, TypeActual=1) + |
-| ufs | R/W | TYPE | Config | Underfrequency Control stop frequency + |
+| hsa        | W          | bool                         | Config        | httpStaAuthentication                                                               |
+| var        | R          | uint8_t                      | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
+| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
+| log        | R/W        | string                       | Config        | load_group_id                                                                       |
+| lop        | R/W        | uint16_t                     | Config        | load_priority                                                                       |
+| lopr       | R/W        | bool                         | Config        | load balancing protected                                                            |
+| lof        | R/W        | uint8_t                      | Config        | load_fallback                                                                       |
+| map        | R/W        | get: legacy set: JsonArray   | Config        | load_mapping (uint8_t[3])                                                           |
 | upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
-| ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
-| utc        | R/W        | string                       | Status        | utc time                                                                            |
-| var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
-| wbw | R | TYPE | Config | WiFi Bandwidth (for both AP and STA) WIFI_BW_HT20=1, WIFI_BW_HT40=2 + |
-| wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
-| wda | R/W | TYPE | Config | disable AccessPoint when cloud is connected + |
-| wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
-| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
-| wifis      | R/W        | array                        | Config        | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: `[{}, {"ssid":"","key":""}]` |
-| wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
-| wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
-| wsl | R | TYPE | Status | WiFi STA error messages log + |
-| wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
-| wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
-| wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |
-| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |
+| pwm        | R          | uint8_t                      | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
+| lfspt      | R          | optional<int64_t>            | Status        | last force single phase toggle                                                      |
+| fsptws     | R          | optional<int64_t>            | Status        | force single phase toggle wished since                                              |
+| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
+| oct        | W          | JsonVariantConst             | Config        | ota from cloud url trigger                                                          |
+| ocu        | R          | get: legacy set: JsonVariantConst | Config        | ota from cloud url, url to download new firmware code from                          |
+| cwe        | R/W        | bool                         | Config        | cloud websocket enabled                                                             |
+| clea       | R          | optional<int64_t>            | Status        | Cloud last error (age)                                                              |
+| cle        | R          | optional<string>             | Status        | Cloud last error                                                                    |
+| cus        | R          | uint8_t                      | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
+| ffb        | R          | uint8_t                      | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
+| fhz        | R          | optional<float>              | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
+| avgfhz     | R          | optional<float>              | Status        | Stromnetz average frequency (~50Hz)                                                 |
+| loa        | R          | get: optional<uint8_t> set: uint8_t | Status        | load balancing ampere                                                               |
+| lot        | R/W        | get: legacy set: JsonVariantConst | Config        | load balancing total amp                                                            |
+| loty       | R/W        | get: uint8_t set: JsonVariantConst | Config        | load balancing type (Static=false, Dynamic=true)                                    |
+| cards      | R/W        | get: legacy set: JsonArray   | Config        | RFID cards array of objects, if you only want to change the second entry, send an array with 1 empty and 1 filled card config object: [{}, {"name":"","energy":"","rfid":""}] |
+| smd        | R          | legacy                       | Status        | smart meter data                                                                    |
+| men        | R/W        | bool                         | Config        | modbus slave enabled                                                                |
+| msp        | R/W        | uint16_t                     | Config        | modbus slave port (requires off/on toggle)                                          |
+| msb        | R/W        | bool                         | Config        | modbus slave swap bytes                                                             |
+| msr        | R/W        | bool                         | Config        | modbus slave swap registers                                                         |
+| data       | R          | string                       | Status        | grafana token from cloud for app                                                    |
+| dll        | R          | string                       | Status        | download link for app csv export                                                    |
+| hai        | R/W        | bool                         | Config        | httpApiEnabled (allows /api/status and /api/set requests)                           |
+| hla        | R/W        | bool                         | Config        | httpLegacyApiEnabled (allows /status and /mqtt requests)                            |
+| mce        | R/W        | bool                         | Config        | MQTT enabled                                                                        |
+| mcu        | R/W        | string                       | Config        | MQTT broker url                                                                     |
+| mcr        | R/W        | bool                         | Config        | MQTT readonly (don't allow api writes from mqtt broker)                             |
+| mtp        | R/W        | get: string set: optional<string> | Config        | MQTT topic prefix (set to null to reset back to the default)                        |
+| mht        | R/W        | get: string set: optional<string> | Config        | MQTT homeassistant topic prefix (set to null to reset back to the default)          |
+| mhe        | R/W        | bool                         | Config        | MQTT enable homeassistant discovery                                                 |
+| mqg        | R/W        | bool                         | Config        | MQTT useGlobalCaStore                                                               |
+| mqcn       | R/W        | bool                         | Config        | MQTT skipCertCommonNameCheck                                                        |
+| mqss       | R/W        | bool                         | Config        | MQTT skipServerVerification                                                         |
+| mcs        | R          | bool                         | Status        | MQTT started                                                                        |
+| mcc        | R          | bool                         | Status        | MQTT connected                                                                      |
+| mcca       | R          | optional<int64_t>            | Status        | MQTT connected (age)                                                                |
+| mlr        | R          | optional<string>             | Status        | MQTT last error                                                                     |
+| mlra       | R          | optional<int64_t>            | Status        | MQTT last error (age)                                                               |
+| ocppe      | R/W        | bool                         | Config        | OCPP enabled                                                                        |
+| ocppu      | R/W        | string                       | Config        | OCPP server url                                                                     |
+| ocppf      | R/W        | optional<uint8_t>            | Config        | OCPP fallback current                                                               |
+| ocppg      | R/W        | bool                         | Config        | OCPP useGlobalCaStore                                                               |
+| ocppcn     | R/W        | bool                         | Config        | OCPP skipCertCommonNameCheck                                                        |
+| ocppss     | R/W        | bool                         | Config        | OCPP skipServerVerification                                                         |
+| ocpps      | R          | bool                         | Status        | OCPP started                                                                        |
+| ocppc      | R          | bool                         | Status        | OCPP connected                                                                      |
+| ocppca     | R          | optional<int64_t>            | Status        | OCPP connected (age)                                                                |
+| ocppa      | R          | bool                         | Status        | OCPP connected and accepted                                                         |
+| ocppaa     | R          | optional<int64_t>            | Status        | OCPP connected and accepted (age)                                                   |
+| ocppti     | R/W        | optional<int>                | Config        | OCPP transaction id                                                                 |
+| ocppte     | R          | optional<int64_t>            | Config        | OCPP transaction ended at (timestamp)                                               |
+| ocppao     | R/W        | bool                         | Config        | OCPP AllowOfflineTxForUnknownId                                                     |
+| ocpplo     | R/W        | bool                         | Config        | OCPP LocalAuthorizeOffline                                                          |
+| ocppla     | R/W        | bool                         | Config        | OCPP LocalAuthListEnabled                                                           |
+| orsch      | R/W        | bool                         | Config        | OCPP requires same card to halt transactions (as a compatibility mode for shitty backends that do not want to follow the ocpp standard) |
+| ocpph      | R/W        | int32_t                      | Config        | ocppHeartbeatInterval                                                               |
+| ocppi      | R/W        | int32_t                      | Config        | ocppMeterValueSampleInterval                                                        |
+| ocppai     | R/W        | int32_t                      | Config        | ocppClockAlignedDataInterval                                                        |
+| ocppd      | R/W        | string                       | Config        | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
+| ocppr      | R/W        | bool                         | Config        | OCPP rotate phases on charger                                                       |
+| ocppcm     | R/W        | uint8_t                      | Status        | OCPP LocalAuthListEnabled                                                           |
+| ocpplea    | R          | optional<int64_t>            | Status        | OCPP last error (age)                                                               |
+| ocpple     | R          | optional<string>             | Status        | OCPP last error                                                                     |
+| ocpprl     | R/W        | bool                         | Config        | OCPP remote log                                                                     |
+| ocppcs     | R          | uint8_t                      | Status        | OCPP connector status (0=Available, 1=Preparing, 2=Charging, 3=SuspendedEVSE, 4=SuspendedEV, 5=Finishing, 6=Reserved, 7=Unavailable, 8=Faulted) |
+| ocppmp     | R          | legacy                       | Status        | ocpp chargepoint max profiles                                                       |
+| ocppdp     | R          | legacy                       | Status        | ocpp chargepoint default profiles                                                   |
+| ocpptp     | R          | legacy                       | Status        | ocpp tx profiles                                                                    |
+| rde        | R/W        | bool                         | Config        | send rfid serial to cloud/api/mqtt (enable lri api key to show rfid numbers)        |
+| lri        | R          | optional<string>             | Status        | last rfid id (only available when sendRfid)                                         |
+| tsi        | R          | optional<string>             | Status        | transaction start rfidid (only available when sendRfid)                             |
+| lrc        | R          | optional<uint8_t>            | Status        | last rfid card index                                                                |
+| lrr        | R          | optional<int64_t>            | Status        | last rfid read (milliseconds since boot)                                            |
+| cmse       | R          | bool                         | Config        | controllerMdnsScanEnabled, set to false to completely disable any MDNS searches (debugging) |
+| cmmr       | R          | uint16_t                     | Config        | controllerMdnsMaxResults                                                            |
+| cms        | R          | string                       | Config        | controllerMdnsService                                                               |
+| cmp        | R          | string                       | Config        | controllerMdnsProto                                                                 |
+| pco        | R/W        | string                       | Config        | controllerCloudKey                                                                  |
+| lcs        | R          | int64_t                      | Status        | last controller scan timestamp in milliseconds since boot time                      |
+| csa        | R          | bool                         | Status        | controller scan active (set to true to start scan)                                  |
+| ctrls      | R          | legacy                       | Status        | Controllers search result                                                           |
+| ccd        | R          | legacy                       | Status        | Connected controller data                                                           |


### PR DESCRIPTION
I have added a mechanism to export the api docs directly from our firmware, and of course it differs between different hardware generations v3, v4, v5,
and I think on github there is sometimes additional information on specific api keys, better documented than the description coming from the firmware.
we have to check, that we dont eliminate any good docs from github by overwriting the texts from the firmware

This new api docs list can be browsed here:
https://github.com/goecharger/go-eCharger-API-v2/blob/export_api_docs_from_firmware/apikeys-en.md