### PR TITLE
Sort apikeys and merge prep for firmwarebased docu

### DIFF
--- a/apikeys-de.md
+++ b/apikeys-de.md
@@ -4,175 +4,175 @@ Deutsch &bull; [English](apikeys-en.md)
 
 | Key        | R/W        | Type                         | Category      | Description                                                                         |
 | ---------- | ---------- | ---------------------------- | ------------- | ----------------------------------------------------------------------------------- |
-| rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
-| rst        | W          | any                          | Other         | Ladestation neustarten                                                              |
-| alw        | R          | bool                         | Status        | Darf das Auto derzeit laden?                                                        |
+| acp        | R/W        | bool                         | Config        | allowChargePause (car compatiblity)                                                 |
+| acs        | R/W        | uint8                        | Config        | access_control user setting (Open=0, Wait=1)                                        |
 | acu        | R          | int                          | Status        | Mit wie vielen Ampere darf das Auto derzeit laden?                                  |
 | adi        | R          | bool                         | Status        | Wird der 16A Adapter benutzt? Limitiert den Ladestrom auf 16A                       |
-| dwo        | R/W        | optional&lt;double&gt;       | Config        | Lade Energy Limit, gemessen in Wh, null bedeutet deaktiviert, nicht mit der Next-Trip Energie zu verwechseln |
-| tpa        | R          | float                        | Status        | 30 Sekunden Gesamtleistungsdurchschnitt (wird für genauere next-trip vorhersagen berechnet) |
-| sse        | R          | string                       | Constant      | serial number                                                                       |
-| eto        | R          | uint64                       | Status        | energy_total, measured in Wh                                                        |
-| wifis      | R/W        | array                        | Config        | WiFi Konfiguration mit SSID und Passwort; Wenn man nur den zweiten Eintrag ändern möchte, einfach das erste Objekt leer lassen: `[{}, {"ssid":"","key":""}]` |
-| delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
-| scan       | R          | array                        | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
-| scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
-| wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |
-| wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
-| wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
-| wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
-| ccw        | R          | optional&lt;object&gt;       | Status        | Currently connected WiFi                                                            |
-| wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
-| wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
-| wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
-| nif        | R          | string                       | Status        | Default route                                                                       |
-| dns        | R          | object                       | Status        | DNS server                                                                          |
-| host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
-| rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
-| tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
-| tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
-| tof        | R/W        | minutes                      | Config        | timezone offset in minutes                                                          |
-| tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
-| utc        | R/W        | string                       | Status        | utc time                                                                            |
-| loc        | R          | string                       | Status        | local time                                                                          |
-| led        | R          | object                       | Status        | internal infos about currently running led animation                                |
-| lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
-| lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
+| alw        | R          | bool                         | Status        | Darf das Auto derzeit laden?                                                        |
 | ama        | R/W        | uint8                        | Config        | ampere_max limit                                                                    |
-| clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
-| bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
 | amp        | R/W        | uint8                        | Config        | requestedCurrent in Ampere, used for display on LED ring and logic calculations     |
-| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
-| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
-| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
-| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
-| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
-| ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
-| lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
-| sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
-| sch_satur  | R/W        | object                       | Config        | scheduler_saturday, control enum values: Disabled=0, Inside=1, Outside=2            |
-| sch_sund   | R/W        | object                       | Config        | scheduler_sunday, control enum values: Disabled=0, Inside=1, Outside=2              |
-| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
-| fsp        | R          | bool                         | Status        | force_single_phase, this is only the result of the charging logic, if it wishes single force or not at the moment |
-| lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
-| del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
-| acs        | R/W        | uint8                        | Config        | access_control user setting (Open=0, Wait=1)                                        |
-| frc        | R/W        | uint8                        | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
-| rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
-| rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
-| car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
-| err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
-| cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
-| pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
-| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
-| trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
-| fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
-| ccu        | R          | optional&lt;object&gt;       | Status        | charge controller update progress (null if no update is in progress)                |
-| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
-| typ        | R          | string                       | Constant      | Devicetype                                                                          |
-| fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
-| ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
-| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
-| cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
-| lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
-| lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
-| lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
-| tma        | R          | array                        | Status        | temperature sensors                                                                 |
 | amt        | R          | int                          | Status        | temperatureCurrentLimit                                                             |
-| nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
-| modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
-| lmsc       | R          | milliseconds                 | Status        | last model status change                                                            |
-| mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
+| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
+| ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
+| atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
+| att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
 | awc        | R/W        | uint8                        | Config        | awattar country (Austria=0, Germany=1)                                              |
-| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
 | awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
+| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
+| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
+| bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
+| cards      | R/W        | array                        | Config        | array mit nuter karten daten (name, energiezähler, aktivierungsstatus)              |
+| cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
+| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
+| cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
+| ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
+| ccu        | R          | optional&lt;object&gt;       | Status        | charge controller update progress (null if no update is in progress)                |
+| ccw        | R          | optional&lt;object&gt;       | Status        | Currently connected WiFi                                                            |
+| cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
+| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
+| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
+| clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
+| cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
+| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
+| cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
+| del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
+| deltaa     | R          | float                        | Other         | deltaA                                                                              |
+| deltap     | R          | float                        | Status        | deltaP                                                                              |
+| delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
+| dns        | R          | object                       | Status        | DNS server                                                                          |
+| dwo        | R/W        | optional&lt;double&gt;       | Config        | Lade Energy Limit, gemessen in Wh, null bedeutet deaktiviert, nicht mit der Next-Trip Energie zu verwechseln |
+| err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
+| esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
+| eto        | R          | uint64                       | Status        | energy_total, measured in Wh                                                        |
+| ferm       | R          | uint8                        | Status        | effectiveRoundingMode                                                               |
+| ffb        | R          | uint8                        | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
+| fhz        | R          | optional&lt;float&gt;        | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
+| fmt        | R/W        | milliseconds                 | Config        | minChargeTime in milliseconds                                                       |
+| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
+| frc        | R/W        | uint8                        | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
+| frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
+| fsp        | R          | bool                         | Status        | force_single_phase, this is only the result of the charging logic, if it wishes single force or not at the moment |
+| fsptws     | R          | optional&lt;milliseconds&gt; | Status        | force single phase toggle wished since                                              |
+| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
+| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
+| fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
+| fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
+| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
+| host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
+| hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
 | ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
 | ids        | R/W        | bool                         | Other         | PvSurPlus Information. z.b.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.}  pGrid < 0 ==> Einspeisen, pAkku < 0 ==> Batterie laden, pPv > 0 ==> PV Produktion, pPv < 0 ==> Standby. Muß alle 5 Sekunden geschrieben werden. Kann bis 10 Sekunden nach Schreiben gelesen werden. pPv und pAkku sind optional |
-| frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
-| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
-| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
-| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
-| fmt        | R/W        | milliseconds                 | Config        | minChargeTime in milliseconds                                                       |
-| att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
-| ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
-| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
-| acp        | R/W        | bool                         | Config        | allowChargePause (car compatiblity)                                                 |
-| cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
-| esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
-| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
-| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
-| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
-| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
-| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
-| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |
-| psmd       | R/W        | milliseconds                 | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
-| sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
-| mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
-| mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
-| ferm       | R          | uint8                        | Status        | effectiveRoundingMode                                                               |
-| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
-| tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
-| tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
-| atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
-| lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
 | inva       | R          | milliseconds                 | Status        | age of inverter data                                                                |
-| pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
-| ppv        | R          | optional&lt;float&gt;        | Status        | pPv in W                                                                            |
-| pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
-| deltap     | R          | float                        | Status        | deltaP                                                                              |
-| pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
-| deltaa     | R          | float                        | Other         | deltaA                                                                              |
-| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
-| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
-| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
+| lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
+| lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
+| lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
+| lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
+| lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
+| lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
+| led        | R          | object                       | Status        | internal infos about currently running led animation                                |
+| lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
+| lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
+| lmsc       | R          | milliseconds                 | Status        | last model status change                                                            |
+| loa        | R          | optional&lt;uint8&gt;        | Status        | load balancing ampere                                                               |
+| loc        | R          | string                       | Status        | local time                                                                          |
+| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
+| lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
+| log        | R/W        | string                       | Config        | load_group_id                                                                       |
+| lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
+| lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
+| loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
+| lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
+| lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
+| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
+| map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
+| mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
 | mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
 | mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
 | mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |
-| su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
-| sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
-| hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
-| var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
-| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
-| log        | R/W        | string                       | Config        | load_group_id                                                                       |
-| lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
-| lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
-| map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
-| upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
-| pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
-| lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
-| fsptws     | R          | optional&lt;milliseconds&gt; | Status        | force single phase toggle wished since                                              |
-| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
-| psm        | R/W        | uint8                        | Config        | phaseSwitchMode (Auto=0, Force_1=1, Force_3=2)                                      |
-| oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
-| ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
-| cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
-| cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
-| ffb        | R          | uint8                        | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
-| fhz        | R          | optional&lt;float&gt;        | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
-| loa        | R          | optional&lt;uint8&gt;        | Status        | load balancing ampere                                                               |
-| lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
-| loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
-| cards      | R/W        | array                        | Config        | array mit nuter karten daten (name, energiezähler, aktivierungsstatus)              |
-| ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
-| ocppu   | R/W  | string   | Config   | OCPP server url              |
-| ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
-| ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
-| ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
-| ocpps   | R    | bool     | Status   | OCPP started                 |
-| ocppc   | R    | bool     | Status   | OCPP connected               |
-| ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
+| modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
+| mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
+| mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
+| nif        | R          | string                       | Status        | Default route                                                                       |
+| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
+| nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
 | ocppa   | R    | bool      | Status   | OCPP connected and accepted |
 | ocppaa  | R | null or milliseconds | Status | OCPP connected and accepted (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
+| ocppc   | R    | bool     | Status   | OCPP connected               |
+| ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppcc  | R/W  | string   | Config   | OCPP client cert             |
+| ocppck  | R/W  | string   | Config   | OCPP client key              |
+| ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
+| ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
+| ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
+| ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
 | ocpph   | R/W | seconds | Config | OCPP heartbeat interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
 | ocppi   | R/W | seconds | Config | OCPP meter values sample interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
-| ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
 | ocpple  | R | string or null | Status | OCPP last error               |
 | ocpplea | R | null or milliseconds | Status | OCPP last error (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
 | ocpprl  | R/W | bool | Config | OCPP remote logging (usually only enabled by go-e support to allow debugging) |
-| ocppck  | R/W  | string   | Config   | OCPP client key              |
-| ocppcc  | R/W  | string   | Config   | OCPP client cert             |
+| ocpps   | R    | bool     | Status   | OCPP started                 |
 | ocppsc  | R/W  | string   | Config   | OCPP server cert             |
+| ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
+| ocppu   | R/W  | string   | Config   | OCPP server url              |
+| oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
+| ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
+| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
+| pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
+| pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
+| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
+| pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
+| pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
+| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
+| ppv        | R          | optional&lt;float&gt;        | Status        | pPv in W                                                                            |
+| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
+| psm        | R/W        | uint8                        | Config        | phaseSwitchMode (Auto=0, Force_1=1, Force_3=2)                                      |
+| psmd       | R/W        | milliseconds                 | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
+| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
+| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
+| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
+| pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
+| rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
+| rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
+| rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
+| rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
+| rst        | W          | any                          | Other         | Ladestation neustarten                                                              |
+| scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
+| scan       | R          | array                        | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
+| sch_satur  | R/W        | object                       | Config        | scheduler_saturday, control enum values: Disabled=0, Inside=1, Outside=2            |
+| sch_sund   | R/W        | object                       | Config        | scheduler_sunday, control enum values: Disabled=0, Inside=1, Outside=2              |
+| sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
+| sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
+| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
+| sse        | R          | string                       | Constant      | serial number                                                                       |
+| su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
+| sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
+| sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
+| tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
+| tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
+| tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
+| tma        | R          | array                        | Status        | temperature sensors                                                                 |
+| tof        | R/W        | minutes                      | Config        | timezone offset in minutes                                                          |
+| tpa        | R          | float                        | Status        | 30 Sekunden Gesamtleistungsdurchschnitt (wird für genauere next-trip vorhersagen berechnet) |
+| trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
+| tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
+| tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
+| typ        | R          | string                       | Constant      | Devicetype                                                                          |
+| upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
+| ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
+| utc        | R/W        | string                       | Status        | utc time                                                                            |
+| var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
+| wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
+| wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
+| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
+| wifis      | R/W        | array                        | Config        | WiFi Konfiguration mit SSID und Passwort; Wenn man nur den zweiten Eintrag ändern möchte, einfach das erste Objekt leer lassen: `[{}, {"ssid":"","key":""}]` |
+| wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
+| wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
+| wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
+| wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
+| wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |
+| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |

--- a/apikeys-en.md
+++ b/apikeys-en.md
@@ -4,175 +4,175 @@
 
 | Key        | R/W        | Type                         | Category      | Description                                                                         |
 | ---------- | ---------- | ---------------------------- | ------------- | ----------------------------------------------------------------------------------- |
-| rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
-| rst        | W          | any                          | Other         | Reboot charger                                                                      |
-| alw        | R          | bool                         | Status        | Is the car allowed to charge at all now?                                            |
+| acp        | R/W        | bool                         | Config        | allowChargePause (car compatiblity)                                                 |
+| acs        | R/W        | uint8                        | Config        | access_control user setting (Open=0, Wait=1)                                        |
 | acu        | R          | int                          | Status        | How many ampere is the car allowed to charge now?                                   |
 | adi        | R          | bool                         | Status        | Is the 16A adapter used? Limits the current to 16A                                  |
-| dwo        | R/W        | optional&lt;double&gt;       | Config        | charging energy limit, measured in Wh, null means disabled, not the next-trip energy |
-| tpa        | R          | float                        | Status        | 30 seconds total power average (used to get better next-trip predictions)           |
-| sse        | R          | string                       | Constant      | serial number                                                                       |
-| eto        | R          | uint64                       | Status        | energy_total, measured in Wh                                                        |
-| wifis      | R/W        | array                        | Config        | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: `[{}, {"ssid":"","key":""}]` |
-| delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
-| scan       | R          | array                        | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
-| scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
-| wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |
-| wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
-| wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
-| wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
-| ccw        | R          | optional&lt;object&gt;       | Status        | Currently connected WiFi                                                            |
-| wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
-| wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
-| wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
-| nif        | R          | string                       | Status        | Default route                                                                       |
-| dns        | R          | object                       | Status        | DNS server                                                                          |
-| host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
-| rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
-| tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
-| tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
-| tof        | R/W        | minutes                      | Config        | timezone offset in minutes                                                          |
-| tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
-| utc        | R/W        | string                       | Status        | utc time                                                                            |
-| loc        | R          | string                       | Status        | local time                                                                          |
-| led        | R          | object                       | Status        | internal infos about currently running led animation                                |
-| lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
-| lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
+| alw        | R          | bool                         | Status        | Is the car allowed to charge at all now?                                            |
 | ama        | R/W        | uint8                        | Config        | ampere_max limit                                                                    |
-| clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
-| bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
-| lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
 | amp        | R/W        | uint8                        | Config        | requestedCurrent in Ampere, used for display on LED ring and logic calculations     |
-| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
-| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
-| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
-| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
-| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
-| ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
-| lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
-| sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
-| sch_satur  | R/W        | object                       | Config        | scheduler_saturday, control enum values: Disabled=0, Inside=1, Outside=2            |
-| sch_sund   | R/W        | object                       | Config        | scheduler_sunday, control enum values: Disabled=0, Inside=1, Outside=2              |
-| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
-| fsp        | R          | bool                         | Status        | force_single_phase, das Rechenergebnis der Ladelogik, ob gerade single phase benötigt wird oder nicht. |
-| lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
-| del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
-| acs        | R/W        | uint8                        | Config        | access_control user setting (Open=0, Wait=1)                                        |
-| frc        | R/W        | uint8                        | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
-| rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
-| rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
-| car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
-| err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
-| cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
-| pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
-| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
-| trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
-| fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
-| ccu        | R          | optional&lt;object&gt;       | Status        | charge controller update progress (null if no update is in progress)                |
-| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
-| typ        | R          | string                       | Constant      | Devicetype                                                                          |
-| fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
-| ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
-| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
-| cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
-| lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
-| lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
-| lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
-| tma        | R          | array                        | Status        | temperature sensors                                                                 |
 | amt        | R          | int                          | Status        | temperatureCurrentLimit                                                             |
-| nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
-| modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
-| lmsc       | R          | milliseconds                 | Status        | last model status change                                                            |
-| mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
+| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
+| ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
+| atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
+| att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
 | awc        | R/W        | uint8                        | Config        | awattar country (Austria=0, Germany=1)                                              |
-| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
 | awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
+| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
+| awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
+| bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
+| cards      | R/W        | array                        | Config        | array of user data (name, energy used, activation state)                            |
+| cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
+| cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
+| cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
+| ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
+| ccu        | R          | optional&lt;object&gt;       | Status        | charge controller update progress (null if no update is in progress)                |
+| ccw        | R          | optional&lt;object&gt;       | Status        | Currently connected WiFi                                                            |
+| cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
+| cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
+| cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
+| clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
+| cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
+| cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
+| cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
+| del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
+| deltaa     | R          | float                        | Other         | deltaA                                                                              | 
+| deltap     | R          | float                        | Status        | deltaP                                                                              |
+| delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
+| dns        | R          | object                       | Status        | DNS server                                                                          |
+| dwo        | R/W        | optional&lt;double&gt;       | Config        | charging energy limit, measured in Wh, null means disabled, not the next-trip energy |
+| err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
+| esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
+| eto        | R          | uint64                       | Status        | energy_total, measured in Wh                                                        |
+| ferm       | R          | uint8                        | Status        | effectiveRoundingMode                                                               |
+| ffb        | R          | uint8                        | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
+| fhz        | R          | optional&lt;float&gt;        | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
+| fmt        | R/W        | milliseconds                 | Config        | minChargeTime in milliseconds                                                       |
+| fna        | R/W        | string                       | Config        | friendlyName                                                                        |
+| frc        | R/W        | uint8                        | Config        | forceState (Neutral=0, Off=1, On=2)                                                 |
+| frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
+| fsp        | R          | bool                         | Status        | force_single_phase, das Rechenergebnis der Ladelogik, ob gerade single phase benötigt wird oder nicht. |
+| fsptws     | R          | optional&lt;milliseconds&gt; | Status        | force single phase toggle wished since                                              |
+| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
+| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
+| fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
+| fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
+| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
+| host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
+| hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
 | ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
 | ids        | R/W        | bool                         | Other         | PvSurPlus information. e.g.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.} pGrid < 0 ==> feed grid, pAkku < 0 ==> load battery, pPv > 0 ==> PV production, pPv < 0 ==> standby. Needed all 5 seconds. Can be read back within 10 seconds after set. pPv und pAkku are optional |
-| frm        | R          | uint8                        | Config        | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2                  |
-| fup        | R/W        | bool                         | Config        | usePvSurplus                                                                        |
-| awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
-| fst        | R/W        | float                        | Config        | startingPower in watts                                                              |
-| fmt        | R/W        | milliseconds                 | Config        | minChargeTime in milliseconds                                                       |
-| att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
-| ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
-| ara        | R/W        | bool                         | Config        | automatic stop remain in aWATTar                                                    |
-| acp        | R/W        | bool                         | Config        | allowChargePause (car compatiblity)                                                 |
-| cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
-| esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
-| fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
-| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
-| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
-| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
-| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
-| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |
-| psmd       | R/W        | milliseconds                 | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
-| sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
-| mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
-| mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
-| ferm       | R          | uint8                        | Status        | effectiveRoundingMode                                                               |
-| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
-| tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
-| tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
-| atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
-| lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
 | inva       | R          | milliseconds                 | Status        | age of inverter data                                                                |
-| pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
-| ppv        | R          | optional&lt;float&gt;        | Status        | pPv in W                                                                            |
-| pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
-| deltap     | R          | float                        | Status        | deltaP                                                                              |
-| pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
-| deltaa     | R          | float                        | Other         | deltaA                                                                              | 
-| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
-| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
-| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
+| lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
+| lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
+| lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
+| lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
+| lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
+| lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
+| led        | R          | object                       | Status        | internal infos about currently running led animation                                |
+| lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
+| lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
+| lmsc       | R          | milliseconds                 | Status        | last model status change                                                            |
+| loa        | R          | optional&lt;uint8&gt;        | Status        | load balancing ampere                                                               |
+| loc        | R          | string                       | Status        | local time                                                                          |
+| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
+| lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
+| log        | R/W        | string                       | Config        | load_group_id                                                                       |
+| lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
+| lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
+| loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
+| lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
+| lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
+| lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
+| map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
+| mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
 | mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
 | mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
 | mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |
-| su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
-| sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
-| hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
-| var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
-| loe        | R/W        | bool                         | Config        | Load balancing enabled                                                              |
-| log        | R/W        | string                       | Config        | load_group_id                                                                       |
-| lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
-| lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
-| map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
-| upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
-| pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
-| lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
-| fsptws     | R          | optional&lt;milliseconds&gt; | Status        | force single phase toggle wished since                                              |
-| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
-| psm        | R/W        | uint8                        | Config        | phaseSwitchMode (Auto=0, Force_1=1, Force_3=2)                                      |
-| oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
-| ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
-| cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
-| cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
-| ffb        | R          | uint8                        | Status        | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2)                         |
-| fhz        | R          | optional&lt;float&gt;        | Status        | Stromnetz frequency (~50Hz) or 0 if unknown                                         |
-| loa        | R          | optional&lt;uint8&gt;        | Status        | load balancing ampere                                                               |
-| lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
-| loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
-| cards      | R/W        | array                        | Config        | array of user data (name, energy used, activation state)                            |
-| ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
-| ocppu   | R/W  | string   | Config   | OCPP server url              |
-| ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
-| ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
-| ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
-| ocpps   | R    | bool     | Status   | OCPP started                 |
-| ocppc   | R    | bool     | Status   | OCPP connected               |
-| ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
+| modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
+| mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
+| mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
+| nif        | R          | string                       | Status        | Default route                                                                       |
+| nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
+| nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
 | ocppa   | R    | bool      | Status   | OCPP connected and accepted |
 | ocppaa  | R | null or milliseconds | Status | OCPP connected and accepted (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
+| ocppc   | R    | bool     | Status   | OCPP connected               |
+| ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppcc  | R/W  | string   | Config   | OCPP client cert             |
+| ocppck  | R/W  | string   | Config   | OCPP client key              |
+| ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
+| ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
+| ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
+| ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
 | ocpph   | R/W | seconds | Config | OCPP heartbeat interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
 | ocppi   | R/W | seconds | Config | OCPP meter values sample interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
-| ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
-| ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
 | ocpple  | R | string or null | Status | OCPP last error               |
 | ocpplea | R | null or milliseconds | Status | OCPP last error (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
 | ocpprl  | R/W | bool | Config | OCPP remote logging (usually only enabled by go-e support to allow debugging) |
-| ocppck  | R/W  | string   | Config   | OCPP client key              |
-| ocppcc  | R/W  | string   | Config   | OCPP client cert             |
+| ocpps   | R    | bool     | Status   | OCPP started                 |
 | ocppsc  | R/W  | string   | Config   | OCPP server cert             |
+| ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
+| ocppu   | R/W  | string   | Config   | OCPP server url              |
+| oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
+| ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
+| oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
+| pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
+| pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
+| pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
+| pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
+| pnp        | R          | uint8                        | Status        | numberOfPhases                                                                      |
+| po         | R/W        | float                        | Config        | prioOffset in W                                                                     |
+| ppv        | R          | optional&lt;float&gt;        | Status        | pPv in W                                                                            |
+| psh        | R/W        | float                        | Config        | phaseSwitchHysteresis in W                                                          |
+| psm        | R/W        | uint8                        | Config        | phaseSwitchMode (Auto=0, Force_1=1, Force_3=2)                                      |
+| psmd       | R/W        | milliseconds                 | Config        | forceSinglePhaseDuration (in milliseconds)                                          |
+| pvopt_averagePAkku | R  | float                        | Status        | averagePAkku                                                                        |
+| pvopt_averagePGrid | R  | float                        | Status        | averagePGrid                                                                        |
+| pvopt_averagePPv | R    | float                        | Status        | averagePPv                                                                          |
+| pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
+| rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
+| rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
+| rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
+| rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
+| rst        | W          | any                          | Other         | Reboot charger                                                                      |
+| scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
+| scan       | R          | array                        | Status        | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
+| sch_satur  | R/W        | object                       | Config        | scheduler_saturday, control enum values: Disabled=0, Inside=1, Outside=2            |
+| sch_sund   | R/W        | object                       | Config        | scheduler_sunday, control enum values: Disabled=0, Inside=1, Outside=2              |
+| sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
+| sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
+| spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
+| sse        | R          | string                       | Constant      | serial number                                                                       |
+| su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
+| sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
+| sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
+| tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
+| tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
+| tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
+| tma        | R          | array                        | Status        | temperature sensors                                                                 |
+| tof        | R/W        | minutes                      | Config        | timezone offset in minutes                                                          |
+| tpa        | R          | float                        | Status        | 30 seconds total power average (used to get better next-trip predictions)           |
+| trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
+| tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
+| tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
+| typ        | R          | string                       | Constant      | Devicetype                                                                          |
+| upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
+| ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
+| utc        | R/W        | string                       | Status        | utc time                                                                            |
+| var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
+| wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
+| wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
+| wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
+| wifis      | R/W        | array                        | Config        | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: `[{}, {"ssid":"","key":""}]` |
+| wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
+| wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
+| wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
+| wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
+| wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |
+| zfo        | R/W        | float                        | Config        | zeroFeedinOffset in W                                                               |

--- a/apikeys-en.md
+++ b/apikeys-en.md
@@ -16,14 +16,18 @@
 | ate        | R/W        | double                       | Config        | automatic stop energy in Wh                                                         |
 | atp        | R          | optional&lt;object&gt;       | Status        | nextTripPlanData (debug)                                                            |
 | att        | R/W        | seconds                      | Config        | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
+| avgfhz | R | TYPE | Status | Stromnetz average frequency (~50Hz) + |
 | awc        | R/W        | uint8                        | Config        | awattar country (Austria=0, Germany=1)                                              |
 | awcp       | R          | optional&lt;object&gt;       | Status        | awattar current price                                                               |
 | awe        | R/W        | bool                         | Config        | useAwattar                                                                          |
 | awp        | R/W        | float                        | Config        | awattarMaxPrice in ct                                                               |
+| awpl | W | TYPE | Status | awattar price list, timestamps are measured in unix-time, seconds since 1970 + |
 | bac        | R/W        | uint8_t                      | Config        | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| bar | R/W | TYPE | Config | Button Allow WiFi AP reset (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) + |
 | car        | R          | optional&lt;uint8&gt;        | Status        | carState, null if internal error (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
 | cards      | R/W        | array                        | Config        | array of user data (name, energy used, activation state)                            |
 | cbl        | R          | optional&lt;int&gt;          | Status        | cable_current_limit in A                                                            |
+| ccd | R | TYPE | Status | Connected controller data + | cch | R/W | TYPE | Config | color_charging, format: #RRGGBB + |
 | cch        | R/W        | string                       | Config        | color_charging, format: #RRGGBB                                                     |
 | cco        | R/W        | double                       | Config        | car consumption (only stored for app)                                               |
 | ccrv       | R          | string                       | Constant      | chargectrl recommended version                                                      |
@@ -32,15 +36,31 @@
 | cdi        | R          | object                       | Status        | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
 | cfi        | R/W        | string                       | Config        | color_finished, format: #RRGGBB                                                     |
 | cid        | R/W        | string                       | Config        | color_idle, format: #RRGGBB                                                         |
+| cle | R | TYPE | Status | Cloud last error + |
+| clea | R | TYPE | Status | Cloud last error (age) + |
+| cll | R | TYPE | Status | Current limits list + |
 | clp        | R/W        | array                        | Config        | current limit presets, max. 5 entries                                               |
+| cmmr | R | TYPE | Config | controllerMdnsMaxResults + |
+| cmp | R | TYPE | Config | controllerMdnsProto + |
+| cms | R | TYPE | Config | controllerMdnsService + |
+| cmse | R | TYPE | Config | controllerMdnsScanEnabled, set to false to completely disable any MDNS searches (debugging) + |
+| csa | R | TYPE | Status | controller scan active + |
+| ct | R/W | TYPE | Config | car type, free text string (max. 64 characters) + |
+| ctrls | R | TYPE | Status | Controllers search result + |
 | cus        | R          | uint8                        | Status        | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
 | cwc        | R/W        | string                       | Config        | color_waitcar, format: #RRGGBB                                                      |
 | cwe        | R/W        | bool                         | Config        | cloud websocket enabled"                                                            |
+| data | R | TYPE | Status | grafana token from cloud for app + |
 | del        | W          | uint8                        | Other         | set this to 0-9 to clear card (erases card name, energy and rfid id)                |
 | deltaa     | R          | float                        | Other         | deltaA                                                                              | 
 | deltap     | R          | float                        | Status        | deltaP                                                                              |
 | delw       | W          | uint8                        | Other         | set this to 0-9 to delete sta config (erases ssid, key, ...)                        |
+| di1 | R/W | TYPE | Config | digital Input 1-phase + |
+| die | R/W | TYPE | Config | digital Input Enabled + |
+| dii | R/W | TYPE | Config | digital Input Inverted + |
+| dll | R | TYPE | Status | download link for app csv export + |
 | dns        | R          | object                       | Status        | DNS server                                                                          |
+| dsrc | R | TYPE | Status | inverter data source + |
 | dwo        | R/W        | optional&lt;double&gt;       | Config        | charging energy limit, measured in Wh, null means disabled, not the next-trip energy |
 | err        | R          | optional&lt;uint8&gt;        | Status        | error, null if internal error (None = 0, FiAc = 1, FiDc = 2, Phase = 3, Overvolt = 4, Overamp = 5, Diode = 6, PpInvalid = 7, GndInvalid = 8, ContactorStuck = 9, ContactorMiss = 10, FiUnknown = 11, Unknown = 12, Overtemp = 13, NoComm = 14, StatusLockStuckOpen = 15, StatusLockStuckLocked = 16, Reserved20 = 20, Reserved21 = 21, Reserved22 = 22, Reserved23 = 23, Reserved24 = 24) |
 | esk        | R/W        | bool                         | Config        | energy set kwh (only stored for app)                                                |
@@ -59,17 +79,25 @@
 | fwc        | R          | string                       | Constant      | firmware from CarControl                                                            |
 | fwv        | R          | string                       | Constant      | FW_VERSION                                                                          |
 | fzf        | R/W        | bool                         | Config        | zeroFeedin                                                                          |
+| gmtr | R/W | TYPE | Config | gridMonitoringTimeReconnection in seconds + |
+| gsa | R/W | TYPE | Status | gridMonitoring last failure + |
+| hai | R/W | TYPE | Config | httpApiEnabled (allows /api/status and /api/set requests) + |
+| hla | R/W | TYPE | Config | httpLegacyApiEnabled (allows /status and /mqtt requests) + |
 | host       | R          | optional&lt;string&gt;       | Status        | hostname used on STA interface                                                      |
 | hsa        | R/W        | bool                         | Config        | httpStaAuthentication                                                               |
 | ido        | R          | optional&lt;object&gt;       | Config        | Inverter data override                                                              |
 | ids        | R/W        | bool                         | Other         | PvSurPlus information. e.g.: {"pGrid": 1000., "pPv": 1400., "pAkku": 2000.} pGrid < 0 ==> feed grid, pAkku < 0 ==> load battery, pPv > 0 ==> PV production, pPv < 0 ==> standby. Needed all 5 seconds. Can be read back within 10 seconds after set. pPv und pAkku are optional |
 | inva       | R          | milliseconds                 | Status        | age of inverter data                                                                |
+| la1 | R/W | TYPE | Config | limit adapter 1-phase (in A) + |
+| la3 | R/W | TYPE | Config | limit adapter 3-phase (in A) + |
+| lbl | R | TYPE | Config | lastButtonHoldLong + |
 | lbp        | R          | milliseconds                 | Status        | lastButtonPress in milliseconds                                                     |
 | lbr        | R/W        | uint8                        | Config        | led_bright, 0-255                                                                   |
 | lccfc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromCharging (in ms)                                             |
 | lccfi      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedFromIdle (in ms)                                                 |
 | lcctc      | R          | optional&lt;milliseconds&gt; | Status        | lastCarStateChangedToCharging (in ms)                                               |
 | lck        | R          | uint8                        | Status        | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
+| lcs | R | TYPE | Status | last controller scan timestamp in milliseconds since boot time + |
 | led        | R          | object                       | Status        | internal infos about currently running led animation                                |
 | lfspt      | R          | optional&lt;milliseconds&gt; | Status        | last force single phase toggle                                                      |
 | lmo        | R/W        | uint8                        | Config        | logic mode (Default=3, Awattar=4, AutomaticStop=5)                                  |
@@ -80,48 +108,82 @@
 | lof        | R/W        | uint8                        | Config        | load_fallback                                                                       |
 | log        | R/W        | string                       | Config        | load_group_id                                                                       |
 | lop        | R/W        | uint16                       | Config        | load_priority                                                                       |
+| lopr | R/W | TYPE | Config | load balancing protected + |
 | lot        | R/W        | uint32                       | Config        | load balancing total amp                                                            |
 | loty       | R/W        | uint8                        | Config        | load balancing type (Static=0, Dynamic=1)                                           |
 | lpsc       | R          | milliseconds                 | Status        | last pv surplus calculation                                                         |
+| lrc | R | TYPE | Status | last rfid card index + |
+| lri | R | TYPE | Status | last rfid id (only available when sendRfid) + |
 | lrn        | W          | uint8                        | Other         | set this to 0-9 to learn last read card id                                          |
+| lrr | R | TYPE | Status | last rfid read (milliseconds since boot) + |
 | lse        | R/W        | bool                         | Config        | led_save_energy                                                                     |
+| lto | R | TYPE | Status | local time offset in milliseconds, tab + rbt + lto = local time + |
+| lwf | R | TYPE | Status | last wifi connect failed (milliseconds since boot) + |
 | map        | R/W        | array                        | Config        | load_mapping (uint8_t[3])                                                           |
 | mca        | R/W        | uint8                        | Config        | minChargingCurrent                                                                  |
+| mcc | R | TYPE | Status | MQTT connected + |
+| mcca | R | TYPE | Status | MQTT connected (age) + |
+| mce | R/W | TYPE | Config | MQTT enabled + |
 | mci        | R/W        | milliseconds                 | Config        | minimumChargingInterval in milliseconds (0 means disabled)                          |
 | mcpd       | R/W        | milliseconds                 | Config        | minChargePauseDuration in milliseconds (0 means disabled)                           |
 | mcpea      | R/W        | optional&lt;milliseconds&gt; | Status        | minChargePauseEndsAt (set to null to abort current minChargePauseDuration)          |
+| mcr | R/W | TYPE | Config | MQTT readonly (don't allow api writes from mqtt broker) + |
+| mcs | R | TYPE | Status | MQTT started + |
+| mcu | R/W | TYPE | Config | MQTT broker url + |
+| men | R/W | TYPE | Config | modbus slave enabled + |
+| mhe | R/W | TYPE | Config | MQTT enable homeassistant discovery + |
+| mht | R/W | TYPE | Config | MQTT homeassistant topic prefix (set to null to reset back to the default) + |
+| mlr | R | TYPE | Status | MQTT last error + |
+| mlra | R | TYPE | Status | MQTT last error (age) + |
 | mmp        | R          | float                        | Status        | maximumMeasuredChargingPower (debug)                                                |
 | modelStatus | R         | uint8                        | Status        | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControlWait=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackGoEDefault=13, ChargingBecauseFallbackGoEScheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackGoEAwattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
 | mptwt      | R/W        | milliseconds                 | Config        | min phase toggle wait time (in milliseconds)                                        |
 | mpwst      | R/W        | milliseconds                 | Config        | min phase wish switch time (in milliseconds)                                        |
+| mqcn | R/W | TYPE | Config | MQTT skipCertCommonNameCheck + |
+| mqg | R/W | TYPE | Config | MQTT useGlobalCaStore + |
+| mqss | R/W | TYPE | Config | MQTT skipServerVerification + |
+| msb | R/W | TYPE | Config | modbus slave swap bytes + |
+| msp | R/W | TYPE | Config | modbus slave port (requires off/on toggle) + |
+| msr | R/W | TYPE | Config | modbus slave swap registers + |
+| mtp | R/W | TYPE | Config | MQTT topic prefix (set to null to reset back to the default) + |
 | nif        | R          | string                       | Status        | Default route                                                                       |
 | nmo        | R/W        | bool                         | Config        | norway_mode / ground check enabled when norway mode is disabled (inverted)          |
 | nrg        | R          | array                        | Status        | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
 | ocppa   | R    | bool      | Status   | OCPP connected and accepted |
 | ocppaa  | R | null or milliseconds | Status | OCPP connected and accepted (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
 | ocppai  | R/W | seconds | Config | OCPP clock aligned data interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
+| ocppao | R/W | TYPE | Status | OCPP AllowOfflineTxForUnknownId + |
 | ocppc   | R    | bool     | Status   | OCPP connected               |
 | ocppca  | R | null or milliseconds | Status | OCPP connected (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
 | ocppcc  | R/W  | string   | Config   | OCPP client cert             |
 | ocppck  | R/W  | string   | Config   | OCPP client key              |
+| ocppcm | R/W | TYPE | Status | OCPP LocalAuthListEnabled + |
 | ocppcn  | R/W  | bool     | Config   | OCPP skipCertCommonNameCheck |
+| ocppcs | R | TYPE | Status | OCPP connector status (0=Available, 1=Preparing, 2=Charging, 3=SuspendedEVSE, 4=SuspendedEV, 5=Finishing, 6=Reserved, 7=Unavailable, 8=Faulted) + |
 | ocppd   | R/W | string | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
 | ocppe   | R/W  | bool     | Config   | OCPP enabled                 |
+| ocppf | R/W | TYPE | Config | OCPP fallback current + |
 | ocppg   | R/W  | bool     | Config   | OCPP use global CA Store     |
 | ocpph   | R/W | seconds | Config | OCPP heartbeat interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
 | ocppi   | R/W | seconds | Config | OCPP meter values sample interval (can also be read/written with `GetConfiguration` and `ChangeConfiguration`) |
+| ocppla | R/W | TYPE | Status | OCPP LocalAuthListEnabled + |
 | ocpple  | R | string or null | Status | OCPP last error               |
 | ocpplea | R | null or milliseconds | Status | OCPP last error (timestamp in milliseconds since reboot) Subtract from reboot time (rbt) to get number of milliseconds since connected |
+| ocpplo | R/W | TYPE | Status | OCPP LocalAuthorizeOffline + |
 | ocppr   | R/W  | bool    | Config   | OCPP rotate phases on charger |
 | ocpprl  | R/W | bool | Config | OCPP remote logging (usually only enabled by go-e support to allow debugging) |
 | ocpps   | R    | bool     | Status   | OCPP started                 |
 | ocppsc  | R/W  | string   | Config   | OCPP server cert             |
 | ocppss  | R/W  | bool     | Config   | OCPP skipServerVerification  |
+| ocppti | R/W | TYPE | Status | OCPP transaction id + |
 | ocppu   | R/W  | string   | Config   | OCPP server url              |
 | oct        | W          | string                       | Other         | firmware update trigger (must specify a branch from ocu)                            |
 | ocu        | R          | array                        | Status        | list of available firmware branches                                                 |
 | oem        | R          | string                       | Constant      | OEM manufacturer                                                                    |
 | pakku      | R          | optional&lt;float&gt;        | Status        | pAkku in W                                                                          |
+| pco | R | TYPE | Config | controllerCloudKey + |
+| pdi | R/W | TYPE | Config | protect Digital Input + |
+| pgr | R/W | TYPE | Config | protect Grid Requirements + |
 | pgrid      | R          | optional&lt;float&gt;        | Status        | pGrid in W                                                                          |
 | pgt        | R/W        | float                        | Config        | pGridTarget in W                                                                    |
 | pha        | R          | optional&lt;array&gt;        | Status        | phases                                                                              |
@@ -137,7 +199,27 @@
 | pwm        | R          | uint8                        | Status        | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
 | rbc        | R          | uint32                       | Status        | reboot_counter                                                                      |
 | rbt        | R          | milliseconds                 | Status        | time since boot in milliseconds                                                     |
+| rdbf | R/W | TYPE | Config | randomDelayStartFlexibleTariffCharging in seconds + |
+| rdbfe | R/W | TYPE | Config | randomDelayStartFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStartFlexibleTariffCharging) + |
+| rdbs | R/W | TYPE | Config | randomDelayStartScheduledCharging in seconds + |
+| rdbse | R/W | TYPE | Config | randomDelayStartScheduledChargingEndsAt (set to null to abort current randomDelayStartScheduledCharging) + |
+| rde | R/W | TYPE | Config | send rfid serial to cloud/api/mqtt (enable lri api key to show rfid numbers) + |
+| rdef | R/W | TYPE | Config | randomDelayStopFlexibleTariffCharging in seconds + |
+| rdefe | R/W | TYPE | Config | randomDelayStopFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStopFlexibleTariffCharging) + |
+| rdes | R/W | TYPE | Config | randomDelayStopScheduledCharging in seconds + |
+| rdese | R/W | TYPE | Config | randomDelayStopScheduledChargingEndsAt (set to null to abort current randomDelayStopScheduledCharging) + |
+| rdpl | R/W | TYPE | Config | randomDelayWhenPluggingCar in seconds + |
+| rdple | R/W | TYPE | Config | randomDelayWhenPluggingCarEndsAt (set to null to abort current randomDelayWhenPluggingCar) + |
+| rdre | R/W | TYPE | Config | randomDelayReconnection in seconds + |
+| rdree | R/W | TYPE | Config | randomDelayReconnectionEndsAt (set to null to abort current randomDelayReconnection) + |
 | rfb        | R          | int                          | Status        | Relay Feedback                                                                      |
+| rmaf | R/W | TYPE | Config | reconnectionMaximumFrequency in Hz + |
+| rmav | R/W | TYPE | Config | reconnectionMaximumVoltage in Volt + |
+| rmif | R/W | TYPE | Config | reconnectionMinimumFrequency in Hz + |
+| rmiv | R/W | TYPE | Config | reconnectionMinimumVoltage in Volt + |
+| rsa | R/W | TYPE | Status | rampup started at + |
+| rsre | R/W | TYPE | Config | rampupAtStartAndReconnectionEnabled + |
+| rsrr | R/W | TYPE | Config | rampupAtStartAndReconnectionRate in %/s + |
 | rssi       | R          | optional&lt;int8&gt;         | Status        | RSSI signal strength                                                                |
 | rst        | W          | any                          | Other         | Reboot charger                                                                      |
 | scaa       | R          | milliseconds                 | Status        | wifi scan age                                                                       |
@@ -147,11 +229,18 @@
 | sch_week   | R/W        | object                       | Config        | scheduler_weekday, control enum values: Disabled=0, Inside=1, Outside=2             |
 | sdp        | R/W        | uint8_t                      | Config        | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
 | sh         | R/W        | float                        | Config        | stopHysteresis in W                                                                 |
+| smd | R | TYPE | Status | smart meter data + |
 | spl3       | R/W        | float                        | Config        | threePhaseSwitchLevel                                                               |
 | sse        | R          | string                       | Constant      | serial number                                                                       |
 | su         | R/W        | bool                         | Config        | simulateUnpluggingShort                                                             |
 | sua        | R/W        | bool                         | Config        | simulateUnpluggingAlways                                                            |
 | sumd       | R/W        | milliseconds                 | Config        | simulate unpluging duration (in milliseconds)                                       |
+| t0h | R/W | TYPE | Config | led strip T0H + |
+| t0l | R/W | TYPE | Config | led strip T0L + |
+| t1h | R/W | TYPE | Config | led strip T1H + |
+| t1l | R/W | TYPE | Config | led strip T1L + |
+| tab | R | TYPE | Status | time at boot in utc in milliseconds, add rbt to get to current utc time + |
+| tcl | R/W | TYPE | Config | temporary current limit (does not change the user current limit, will be reset after 10min if not updated regulary) + |
 | tds        | R/W        | uint8                        | Config        | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2       |
 | tlf        | R          | bool                         | Status        | testLadungFinished (debug)                                                          |
 | tls        | R          | bool                         | Status        | testLadungStarted (debug)                                                           |
@@ -160,18 +249,27 @@
 | tpa        | R          | float                        | Status        | 30 seconds total power average (used to get better next-trip predictions)           |
 | trx        | R/W        | optional&lt;uint8&gt;        | Status        | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
 | tse        | R/W        | bool                         | Config        | time server enabled (NTP)                                                           |
+| tsi | R | TYPE | Status | transaction start rfidid (only available when sendRfid) + |
 | tsss       | R          | uint8                        | Config        | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2)                       |
 | typ        | R          | string                       | Constant      | Devicetype                                                                          |
+| tzt | R/W | TYPE | Config | timezone type, freetext string for app selection + |
+| ufa | R/W | TYPE | Config | Underfrequency Control activation threshold + |
+| ufe | R/W | TYPE | Config | Underfrequency Control enabled + |
+| ufm | R/W | TYPE | Config | Underfrequency Control mode (TypeNominal=0, TypeActual=1) + |
+| ufs | R/W | TYPE | Config | Underfrequency Control stop frequency + |
 | upo        | R/W        | bool                         | Config        | unlock_power_outage                                                                 |
 | ust        | R/W        | uint8                        | Config        | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2)                               |
 | utc        | R/W        | string                       | Status        | utc time                                                                            |
 | var        | R          | uint8                        | Constant      | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A)                      |
+| wbw | R | TYPE | Config | WiFi Bandwidth (for both AP and STA) WIFI_BW_HT20=1, WIFI_BW_HT40=2 + |
 | wcb        | R          | string                       | Status        | WiFi current mac address                                                            |
+| wda | R/W | TYPE | Config | disable AccessPoint when cloud is connected + |
 | wfb        | R          | array                        | Status        | WiFi failed mac addresses                                                           |
 | wh         | R          | double                       | Status        | energy in Wh since car connected                                                    |
 | wifis      | R/W        | array                        | Config        | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: `[{}, {"ssid":"","key":""}]` |
 | wpb        | R          | array                        | Status        | WiFi planned mac addresses                                                          |
 | wsc        | R          | uint8                        | Status        | WiFi STA error count                                                                |
+| wsl | R | TYPE | Status | WiFi STA error messages log + |
 | wsm        | R          | string                       | Status        | WiFi STA error message                                                              |
 | wsms       | R          | uint8                        | Status        | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3)            |
 | wst        | R          | uint8                        | Status        | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=8, DISCONNECTING=9, NO_SHIELD=10 (for compatibility with WiFi Shield library)) |

--- a/apikeys_firmware_sorted-en.md
+++ b/apikeys_firmware_sorted-en.md
@@ -1,0 +1,266 @@
+[Deutsch](apikeys-de.md) &bull; English
+
+# API Keys
+
+| Key        | R/W        | Type                         | Category      | Description                                                                         |
+| ---------- | ---------- | ---------------------------- | ------------- | ----------------------------------------------------------------------------------- |
+| acp | R/W | TYPE | Config | allowChargePause |
+| acs | R/W | TYPE | Config | access_control user setting (Open=0, Wait=1, EVCMS=2) |
+| acu | R | TYPE | Status | How many ampere is the car allowed to charge now? |
+| adi | R | TYPE | Status | Is the 16A adapter used? Limits the current to 16A |
+| alw | R | TYPE | Status | Is the car allowed to charge at all now? |
+| ama | R/W | TYPE | Config | ampere_max limit |
+| amp | R/W | TYPE | Config | requestedCurrent, used for display on LED ring and logic calculations |
+| amt | R | TYPE | Status | temperatureCurrentLimit |
+| ara | R/W | TYPE | Config | automatic stop remain in aWATTar |
+| ate | R/W | TYPE | Config | nextTripEnergy in Wh |
+| atp | R | TYPE | Status | nextTripPlanData |
+| att | R/W | TYPE | Config | automatic stop time in seconds since day begin, calculation: (hours*3600)+(minutes*60)+(seconds) |
+| avgfhz | R | TYPE | Status | Stromnetz average frequency (~50Hz) |
+| awc | R/W | TYPE | Config | awattar country (Austria=0, Germany=1,...) |
+| awcp | R | TYPE | Status | awattar current price |
+| awe | R/W | TYPE | Config | useAwattar |
+| awp | R/W | TYPE | Config | awattarMaxPrice in ct |
+| awpl | W | TYPE | Status | awattar price list, timestamps are measured in unix-time, seconds since 1970 |
+| bac | R/W | TYPE | Config | Button allow Current change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| bar | R/W | TYPE | Config | Button Allow WiFi AP reset (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| car | R | TYPE | Status | charge ctrl car state, null if no connection to chargectrl established (Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5) |
+| cards | R/W | TYPE | Config | RFID cards array of objects, if you only want to change the second entry, send an array with 1 empty and 1 filled card config object: [{}, {"name":"","energy":"","rfid":""}] |
+| cbl | R | TYPE | Status | cable_current_limit in A |
+| ccd | R | TYPE | Status | Connected controller data || cch | R/W | TYPE | Config | color_charging, format: #RRGGBB |
+| cco | R/W | TYPE | Config | car consumption (for app) |
+| ccw | R | TYPE | Status | Currently connected WiFi |
+| cdi | R | TYPE | Status | charging duration info (null=no charging in progress, type=0 counter going up, type=1 duration in ms) |
+| cfi | R/W | TYPE | Config | color_finished, format: #RRGGBB |
+| cid | R/W | TYPE | Config | color_idle, format: #RRGGBB |
+| cle | R | TYPE | Status | Cloud last error |
+| clea | R | TYPE | Status | Cloud last error (age) |
+| cll | R | TYPE | Status | Current limits list |
+| clp | R/W | TYPE | Config | current limit presets, max. 5 entries |
+| cmmr | R | TYPE | Config | controllerMdnsMaxResults |
+| cmp | R | TYPE | Config | controllerMdnsProto |
+| cms | R | TYPE | Config | controllerMdnsService |
+| cmse | R | TYPE | Config | controllerMdnsScanEnabled, set to false to completely disable any MDNS searches (debugging) |
+| csa | R | TYPE | Status | controller scan active |
+| ct | R/W | TYPE | Config | car type, free text string (max. 64 characters) |
+| ctrls | R | TYPE | Status | Controllers search result |
+| cus | R | TYPE | Status | Cable unlock status (Unknown=0, Unlocked=1, UnlockFailed=2, Locked=3, LockFailed=4, LockUnlockPowerout=5) |
+| cwc | R/W | TYPE | Config | color_waitcar, format: #RRGGBB |
+| cwe | R/W | TYPE | Config | cloud websocket enabled |
+| data | R | TYPE | Status | grafana token from cloud for app |
+| del | W | TYPE | Unknown | set this to 0-9 to clear card (erases card name, energy and rfid id) |
+| deltaa | R | TYPE | Unknown | deltaA |
+| deltap | R | TYPE | Status | deltaP |
+| delw | W | TYPE | Unknown | set this to 0-9 to delete sta config (erases ssid, key, ...) |
+| di1 | R/W | TYPE | Config | digital Input 1-phase |
+| die | R/W | TYPE | Config | digital Input Enabled |
+| dii | R/W | TYPE | Config | digital Input Inverted |
+| dll | R | TYPE | Status | download link for app csv export |
+| dns | R | TYPE | Status | dns servers |
+| dsrc | R | TYPE | Status | inverter data source |
+| dwo | R/W | TYPE | Config | energy limit, measured in Wh, null means disabled, not the next trip energy |
+| err | R | TYPE | Status | charge ctrl error, null if no connection to charge ctrl established (None=0, FiAc=1, FiDc=2, Phase=3, Overvolt=4, Overamp=5, Diode=6, PpInvalid=7, GndInvalid=8, ContactorStuck=9, ContactorMiss=10, StatusLockStuckOpen=12, StatusLockStuckLocked=13, FiUnknown=14, Unknown=15, Overtemp=16, NoComm=17, CpInvalid=18) |
+| esk | R/W | TYPE | Config | energy set kwh (for app) |
+| eto | R | TYPE | Status | energy_total, measured in Wh |
+| ffb | R | TYPE | Status | lock feedback (NoProblem=0, ProblemLock=1, ProblemUnlock=2) |
+| fhz | R | TYPE | Status | Stromnetz frequency (~50Hz) or 0 if unknown |
+| fmt | R/W | TYPE | Config | minChargeTime in milliseconds |
+| fna | R/W | TYPE | Config | friendlyName |
+| frc | R/W | TYPE | Config | forceState (Neutral=0, Off=1, On=2) |
+| frm | R/W | TYPE | Config | roundingMode PreferPowerFromGrid=0, Default=1, PreferPowerToGrid=2 |
+| fsp | R/W | TYPE | Status | force_single_phase |
+| fsptws | R | TYPE | Status | force single phase toggle wished since |
+| fst | R/W | TYPE | Config | startingPower in watts |
+| fup | R/W | TYPE | Config | usePvSurplus |
+| fwv | R | TYPE | Status | FW_VERSION |
+| fzf | R/W | TYPE | Config | zeroFeedin |
+| gmtr | R/W | TYPE | Config | gridMonitoringTimeReconnection in seconds |
+| gsa | R/W | TYPE | Status | gridMonitoring last failure |
+| hai | R/W | TYPE | Config | httpApiEnabled (allows /api/status and /api/set requests) |
+| hla | R/W | TYPE | Config | httpLegacyApiEnabled (allows /status and /mqtt requests) |
+| host | R | TYPE | Status | configured hostname |
+| hsa | W | TYPE | Config | httpStaAuthentication |
+| ids | W | TYPE | Status | inverter data setter {"pGrid": 1000., "pPv": 1000., "pAkku": 1000.} |
+| inva | R | TYPE | Status | age of inverter data |
+| la1 | R/W | TYPE | Config | limit adapter 1-phase (in A) |
+| la3 | R/W | TYPE | Config | limit adapter 3-phase (in A) |
+| lbl | R | TYPE | Config | lastButtonHoldLong |
+| lbp | R | TYPE | Config | lastButtonPress |
+| lbr | R/W | TYPE | Config | led_bright, 0-255 |
+| lccfc | R | TYPE | Status | lastCarStateChangedFromCharging (in ms) |
+| lccfi | R | TYPE | Status | lastCarStateChangedFromIdle (in ms) |
+| lcctc | R | TYPE | Status | lastCarStateChangedToCharging (in ms) |
+| lck | R | TYPE | Status | Effective lock setting, as sent to Charge Ctrl (Normal=0, AutoUnlock=1, AlwaysLock=2, ForceUnlock=3) |
+| lcs | R | TYPE | Status | last controller scan timestamp in milliseconds since boot time |
+| led | R | TYPE | Status | LED animation |
+| lfspt | R | TYPE | Status | last force single phase toggle |
+| lmo | R/W | TYPE | Config | logic mode (Default=3, Awattar=4, NextTrip=5) |
+| lmsc | R | TYPE | Status | last model status change |
+| loa | R | TYPE | Status | load balancing ampere |
+| loc | R | TYPE | Status | local time |
+| loe | R/W | TYPE | Config | Load balancing enabled |
+| lof | R/W | TYPE | Config | load_fallback |
+| log | R/W | TYPE | Config | load_group_id |
+| lop | R/W | TYPE | Config | load_priority |
+| lopr | R/W | TYPE | Config | load balancing protected |
+| lot | R/W | TYPE | Config | load balancing total amp |
+| loty | R/W | TYPE | Config | load balancing type (Static=false, Dynamic=true) |
+| lpsc | R | TYPE | Status | last pv surplus calcuation |
+| lrc | R | TYPE | Status | last rfid card index |
+| lri | R | TYPE | Status | last rfid id (only available when sendRfid) |
+| lrn | W | TYPE | Config | set this to 0-9 to learn last read card id |
+| lrr | R | TYPE | Status | last rfid read (milliseconds since boot) |
+| lse | R/W | TYPE | Config | led_save_energy |
+| lto | R | TYPE | Status | local time offset in milliseconds, tab + rbt + lto = local time |
+| lwf | R | TYPE | Status | last wifi connect failed (milliseconds since boot) |
+| map | R/W | TYPE | Config | load_mapping (uint8_t[3]) |
+| mca | R/W | TYPE | Config | minChargingCurrent |
+| mcc | R | TYPE | Status | MQTT connected |
+| mcca | R | TYPE | Status | MQTT connected (age) |
+| mce | R/W | TYPE | Config | MQTT enabled |
+| mci | R/W | TYPE | Config | minimumChargingInterval in milliseconds (0 means disabled) |
+| mcpd | R/W | TYPE | Config | minChargePauseDuration in milliseconds (0 means disabled) |
+| mcpea | R/W | TYPE | Config | minChargePauseEndsAt (set to null to abort current minChargePauseDuration) |
+| mcr | R/W | TYPE | Config | MQTT readonly (don't allow api writes from mqtt broker) |
+| mcs | R | TYPE | Status | MQTT started |
+| mcu | R/W | TYPE | Config | MQTT broker url |
+| men | R/W | TYPE | Config | modbus slave enabled |
+| mhe | R/W | TYPE | Config | MQTT enable homeassistant discovery |
+| mht | R/W | TYPE | Config | MQTT homeassistant topic prefix (set to null to reset back to the default) |
+| mlr | R | TYPE | Status | MQTT last error |
+| mlra | R | TYPE | Status | MQTT last error (age) |
+| mmp | R | TYPE | Status | maximumMeasuredChargingPower |
+| modelStatus | R | TYPE | Status | Reason why we allow charging or not right now (NotChargingBecauseNoChargeCtrlData=0, NotChargingBecauseOvertemperature=1, NotChargingBecauseAccessControl=2, ChargingBecauseForceStateOn=3, NotChargingBecauseForceStateOff=4, NotChargingBecauseScheduler=5, NotChargingBecauseEnergyLimit=6, ChargingBecauseAwattarPriceLow=7, ChargingBecauseAutomaticStopTestLadung=8, ChargingBecauseAutomaticStopNotEnoughTime=9, ChargingBecauseAutomaticStop=10, ChargingBecauseAutomaticStopNoClock=11, ChargingBecausePvSurplus=12, ChargingBecauseFallbackV2Default=13, ChargingBecauseFallbackV2Scheduler=14, ChargingBecauseFallbackDefault=15, NotChargingBecauseFallbackV2Awattar=16, NotChargingBecauseFallbackAwattar=17, NotChargingBecauseFallbackAutomaticStop=18, ChargingBecauseCarCompatibilityKeepAlive=19, ChargingBecauseChargePauseNotAllowed=20, NotChargingBecauseSimulateUnplugging=22, NotChargingBecausePhaseSwitch=23, NotChargingBecauseMinPauseDuration=24, NotChargingBecauseError=26, NotChargingBecauseLoadManagementDoesntWant=27, NotChargingBecauseOcppDoesntWant=28, NotChargingBecauseReconnectDelay=29, NotChargingBecauseAdapterBlocking=30, NotChargingBecauseUnderfrequencyControl=31, NotChargingBecauseUnbalancedLoad=32, ChargingBecauseDischargingPvBattery=33, NotChargingBecauseGridMonitoring=34, NotChargingBecauseOcppFallback=35) |
+| mptwt | R/W | TYPE | Config | min phase toggle wait time (in milliseconds) |
+| mpwst | R/W | TYPE | Config | min phase wish switch time (in milliseconds) |
+| mqcn | R/W | TYPE | Config | MQTT skipCertCommonNameCheck |
+| mqg | R/W | TYPE | Config | MQTT useGlobalCaStore |
+| mqss | R/W | TYPE | Config | MQTT skipServerVerification |
+| msb | R/W | TYPE | Config | modbus slave swap bytes |
+| msp | R/W | TYPE | Config | modbus slave port (requires off/on toggle) |
+| msr | R/W | TYPE | Config | modbus slave swap registers |
+| mtp | R/W | TYPE | Config | MQTT topic prefix (set to null to reset back to the default) |
+| nif | R | TYPE | Status | Default route |
+| nmo | R/W | TYPE | Config | norway_mode / ground check enabled when norway mode is disabled |
+| nrg | R | TYPE | Status | energy array, U (L1, L2, L3, N), I (L1, L2, L3), P (L1, L2, L3, N, Total), pf (L1, L2, L3, N) |
+| ocppa | R | TYPE | Status | OCPP connected and accepted |
+| ocppaa | R | TYPE | Status | OCPP connected and accepted (age) |
+| ocppai | R/W | TYPE | Config | ocppClockAlignedDataInterval |
+| ocppao | R/W | TYPE | Status | OCPP AllowOfflineTxForUnknownId |
+| ocppc | R | TYPE | Status | OCPP connected |
+| ocppca | R | TYPE | Status | OCPP connected (age) |
+| ocppcm | R/W | TYPE | Status | OCPP LocalAuthListEnabled |
+| ocppcn | R/W | TYPE | Config | OCPP skipCertCommonNameCheck |
+| ocppcs | R | TYPE | Status | OCPP connector status (0=Available, 1=Preparing, 2=Charging, 3=SuspendedEVSE, 4=SuspendedEV, 5=Finishing, 6=Reserved, 7=Unavailable, 8=Faulted) |
+| ocppd | R/W | TYPE | Config | OCPP dummy card id (used when no card has been used and charging is already allowed / starting) |
+| ocppe | R/W | TYPE | Config | OCPP enabled |
+| ocppf | R/W | TYPE | Config | OCPP fallback current |
+| ocppg | R/W | TYPE | Config | OCPP useGlobalCaStore |
+| ocpph | R/W | TYPE | Config | ocppHeartbeatInterval |
+| ocppi | R/W | TYPE | Config | ocppMeterValueSampleInterval |
+| ocppla | R/W | TYPE | Status | OCPP LocalAuthListEnabled |
+| ocpple | R | TYPE | Status | OCPP last error |
+| ocpplea | R | TYPE | Status | OCPP last error (age) |
+| ocpplo | R/W | TYPE | Status | OCPP LocalAuthorizeOffline |
+| ocppr | R/W | TYPE | Config | OCPP rotate phases on charger |
+| ocpprl | R/W | TYPE | Config | OCPP remote log |
+| ocpps | R | TYPE | Status | OCPP started |
+| ocppss | R/W | TYPE | Config | OCPP skipServerVerification |
+| ocppti | R/W | TYPE | Status | OCPP transaction id |
+| ocppu | R/W | TYPE | Config | OCPP server url |
+| oct | W | TYPE | Config | ota from cloud url trigger |
+| ocu | R | TYPE | Config | ota from cloud url, url to download new firmware code from |
+| oem | R | TYPE | Constant | OEM manufacturer |
+| pakku | R | TYPE | Status | pAkku in W |
+| pco | R | TYPE | Config | controllerCloudKey |
+| pdi | R/W | TYPE | Config | protect Digital Input |
+| pgr | R/W | TYPE | Config | protect Grid Requirements |
+| pgrid | R | TYPE | Status | pGrid in W |
+| pgt | R/W | TYPE | Config | pGridTarget in W |
+| pha | R | TYPE | Status | phases |
+| pnp | R | TYPE | Status | numberOfPhases |
+| po | R/W | TYPE | Config | prioOffset in W |
+| ppv | R | TYPE | Status | pPv in W |
+| psh | R/W | TYPE | Config | phaseSwitchHysteresis in W |
+| psmd | R/W | TYPE | Config | forceSinglePhaseDuration (in milliseconds) |
+| pvopt_averagePAkku | R | TYPE | Status | averagePAkku |
+| pvopt_averagePGrid | R | TYPE | Status | averagePGrid |
+| pvopt_averagePPv | R | TYPE | Status | averagePPv |
+| pwm | R | TYPE | Status | phase wish mode for debugging / only for pv optimizing / used for timers later (Force_3=0, Wish_1=1, Wish_3=2) |
+| rbc | R | TYPE | Status | reboot_counter |
+| rbt | R | TYPE | Status | time since boot in milliseconds |
+| rdbf | R/W | TYPE | Config | randomDelayStartFlexibleTariffCharging in seconds |
+| rdbfe | R/W | TYPE | Config | randomDelayStartFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStartFlexibleTariffCharging) |
+| rdbs | R/W | TYPE | Config | randomDelayStartScheduledCharging in seconds |
+| rdbse | R/W | TYPE | Config | randomDelayStartScheduledChargingEndsAt (set to null to abort current randomDelayStartScheduledCharging) |
+| rde | R/W | TYPE | Config | send rfid serial to cloud/api/mqtt (enable lri api key to show rfid numbers) |
+| rdef | R/W | TYPE | Config | randomDelayStopFlexibleTariffCharging in seconds |
+| rdefe | R/W | TYPE | Config | randomDelayStopFlexibleTariffChargingEndsAt (set to null to abort current randomDelayStopFlexibleTariffCharging) |
+| rdes | R/W | TYPE | Config | randomDelayStopScheduledCharging in seconds |
+| rdese | R/W | TYPE | Config | randomDelayStopScheduledChargingEndsAt (set to null to abort current randomDelayStopScheduledCharging) |
+| rdpl | R/W | TYPE | Config | randomDelayWhenPluggingCar in seconds |
+| rdple | R/W | TYPE | Config | randomDelayWhenPluggingCarEndsAt (set to null to abort current randomDelayWhenPluggingCar) |
+| rdre | R/W | TYPE | Config | randomDelayReconnection in seconds |
+| rdree | R/W | TYPE | Config | randomDelayReconnectionEndsAt (set to null to abort current randomDelayReconnection) |
+| rfb | R | TYPE | Status | relay feedback |
+| rmaf | R/W | TYPE | Config | reconnectionMaximumFrequency in Hz |
+| rmav | R/W | TYPE | Config | reconnectionMaximumVoltage in Volt |
+| rmif | R/W | TYPE | Config | reconnectionMinimumFrequency in Hz |
+| rmiv | R/W | TYPE | Config | reconnectionMinimumVoltage in Volt |
+| rsa | R/W | TYPE | Status | rampup started at |
+| rsre | R/W | TYPE | Config | rampupAtStartAndReconnectionEnabled |
+| rsrr | R/W | TYPE | Config | rampupAtStartAndReconnectionRate in %/s |
+| rssi | R | TYPE | Status | RSSI signal strength |
+| rst | W | TYPE | Unknown | Reset the charger and chargectrl |
+| scaa | R | TYPE | Status | wifi scan age |
+| scan | R | TYPE | Status | wifi scan result (encryptionType: OPEN=0, WEP=1, WPA_PSK=2, WPA2_PSK=3, WPA_WPA2_PSK=4, WPA2_ENTERPRISE=5, WPA3_PSK=6, WPA2_WPA3_PSK=7) |
+| sch_satur | R/W | TYPE | Config | scheduler_saturday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| sch_sund | R/W | TYPE | Config | scheduler_sunday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| sch_week | R/W | TYPE | Config | scheduler_weekday, control enum values: Disabled=0, Allow=1, Block=2, AllowFromGrid=3, BlockFromGrid=4 |
+| sdp | R/W | TYPE | Config | Button Allow Force change (0=AlwaysLock, 1=LockWhenCarIsConnected, 2=LockWhenCarIsCharging, 3=NeverLock) |
+| sh | R/W | TYPE | Config | stopHysteresis in W |
+| smd | R | TYPE | Status | smart meter data |
+| spl3 | R/W | TYPE | Config | threePhaseSwitchLevel |
+| sse | R | TYPE | Constant | serial number |
+| su | R/W | TYPE | Config | simulateUnpluggingShort |
+| sua | R/W | TYPE | Config | simulateUnpluggingAlways |
+| sumd | R/W | TYPE | Config | simulate unpluging duration (in milliseconds) |
+| t0h | R/W | TYPE | Config | led strip T0H |
+| t0l | R/W | TYPE | Config | led strip T0L |
+| t1h | R/W | TYPE | Config | led strip T1H |
+| t1l | R/W | TYPE | Config | led strip T1L |
+| tab | R | TYPE | Status | time at boot in utc in milliseconds, add rbt to get to current utc time |
+| tcl | R/W | TYPE | Config | temporary current limit (does not change the user current limit, will be reset after 10min if not updated regulary) |
+| tds | R/W | TYPE | Config | timezone daylight saving mode, None=0, EuropeanSummerTime=1, UsDaylightTime=2, AustralianDaylightTime=3 |
+| tlf | R | TYPE | Status | testLadungFinished |
+| tls | R | TYPE | Status | testLadungStarted |
+| tma | R | TYPE | Status | temperature sensors |
+| tof | R/W | TYPE | Config | timezone offset in minutes |
+| tpa | R | TYPE | Status | 30 seconds total power average (not used by next-trip, use mmp for next-trip related power) |
+| trx | R/W | TYPE | Status | transaction, null when no transaction, 0 when without card, otherwise cardIndex + 1 (1: 0. card, 2: 1. card, ...) |
+| tse | R/W | TYPE | Config | time server enabled |
+| tsi | R | TYPE | Status | transaction start rfidid (only available when sendRfid) |
+| tsss | R | TYPE | Status | time server sync status (RESET=0, COMPLETED=1, IN_PROGRESS=2) |
+| typ | R | TYPE | Constant | Devicetype |
+| tzt | R/W | TYPE | Config | timezone type, freetext string for app selection |
+| ufa | R/W | TYPE | Config | Underfrequency Control activation threshold |
+| ufe | R/W | TYPE | Config | Underfrequency Control enabled |
+| ufm | R/W | TYPE | Config | Underfrequency Control mode (TypeNominal=0, TypeActual=1) |
+| ufs | R/W | TYPE | Config | Underfrequency Control stop frequency |
+| upo | R/W | TYPE | Config | unlock_power_outage |
+| ust | R/W | TYPE | Config | unlock_setting (Normal=0, AutoUnlock=1, AlwaysLock=2) |
+| utc | R/W | TYPE | Status | utc time |
+| var | R | TYPE | Constant | variant: max Ampere value of unit (11: 11kW/16A, 22: 22kW/32A) |
+| wbw | R | TYPE | Config | WiFi Bandwidth (for both AP and STA) WIFI_BW_HT20=1, WIFI_BW_HT40=2 |
+| wcb | R | TYPE | Status | WiFi current mac address (bssid connecting to) |
+| wda | R/W | TYPE | Config | disable AccessPoint when cloud is connected |
+| wfb | R | TYPE | Status | WiFi failed mac addresses (bssids) |
+| wh | R | TYPE | Status | energy in Wh since car connected |
+| wifis | R/W | TYPE | Config | wifi configurations with ssids and keys, if you only want to change the second entry, send an array with 1 empty and 1 filled wifi config object: [{}, {"ssid":"","key":""}] |
+| wpb | R | TYPE | Status | WiFi planned mac addresses (future bssids) |
+| wsc | R | TYPE | Status | WiFi STA error count |
+| wsl | R | TYPE | Status | WiFi STA error messages log |
+| wsm | R | TYPE | Status | WiFi STA error message |
+| wsms | R | TYPE | Status | WiFi state machine state (None=0, Scanning=1, Connecting=2, Connected=3) |
+| wst | R | TYPE | Status | WiFi STA status (IDLE_STATUS=0, NO_SSID_AVAIL=1, SCAN_COMPLETED=2, CONNECTED=3, CONNECT_FAILED=4, CONNECTION_LOST=5, DISCONNECTED=6, CONNECTING=7, DISCONNECTING=8, NO_SHIELD=9, WAITING_FOR_IP=10 (for compatibility with WiFi Shield library)) |
+| zfo | R/W | TYPE | Config | zeroFeedinOffset in W |


### PR DESCRIPTION
**First commit**
Sort apikeys-de.md and apikeys-en.md

**Second commit**
Add apikeys_firmware_sorted-en.md. Took it from export_api_docs_from_firmware/ branch and sorted it.
Add keys, which were missing in apikeys-en.md from apikeys_firmware_sorted-en.md and have apikeys-en.md  sorted alphabetically

Now it is possible to compare apikeys-en.md and apikeys_firmware_sorted-en.md and decide which description is better
apikeys_firmware_sorted-en.md can be deleted later on. I guess go-e can only do this

**Comments**
All new entries (taken from apikeys_firmware_sorted-en.md) in apikeys-en.md are marked with + | at the end. Shall be removed once description merge is done.

There are about 10 commands which are obsolete, because now contains 276 lines and apikeys_firmware_sorted-en.md contains 266 lines. Need to find them out.
